### PR TITLE
Adapt global gql identification system

### DIFF
--- a/graphql-schema/base.graphql
+++ b/graphql-schema/base.graphql
@@ -2,8 +2,3 @@
 A type denoting an exact moment in time.
 """
 scalar DateTime
-
-"""
-A type denoting a date.
-"""
-scalar Date

--- a/graphql-schema/block.graphql
+++ b/graphql-schema/block.graphql
@@ -10,4 +10,5 @@ type Block implements Node {
 
 extend type Query {
   getLatestBlock: Block
+  queryBlockByHash(hash: ID!): Block
 }

--- a/graphql-schema/block.graphql
+++ b/graphql-schema/block.graphql
@@ -1,4 +1,5 @@
-type Block {
+type Block implements Node {
+  id: ID!
   height: Int!
   hash: String!
   numOfTxs: Int!

--- a/graphql-schema/relay.graphql
+++ b/graphql-schema/relay.graphql
@@ -1,0 +1,10 @@
+interface Node {
+  id: ID!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}

--- a/graphql-schema/relay.graphql
+++ b/graphql-schema/relay.graphql
@@ -8,3 +8,7 @@ type PageInfo {
   startCursor: String
   endCursor: String
 }
+
+extend type Query {
+  node(id: ID!): Node
+}

--- a/graphql-schema/test.graphql
+++ b/graphql-schema/test.graphql
@@ -1,4 +1,4 @@
-type Test {
+type Test implements Node {
   id: ID!
   string: String!
   int: Int!

--- a/graphql-schema/test.graphql
+++ b/graphql-schema/test.graphql
@@ -15,5 +15,5 @@ extend type Query {
 }
 
 extend type Mutation {
-  createTest(input: CreateTest!): ID!
+  createTest(input: CreateTest!): Test!
 }

--- a/graphql-server/go.mod
+++ b/graphql-server/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require (
 	github.com/99designs/gqlgen v0.17.4
+	github.com/cychiuae/go-dataloader v1.0.1
+	github.com/getsentry/sentry-go v0.13.0
 	github.com/gin-gonic/gin v1.7.7
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
@@ -12,8 +14,6 @@ require (
 	github.com/uptrace/bun/driver/pgdriver v1.1.4
 	github.com/uptrace/bun/extra/bundebug v1.1.4
 	github.com/vektah/gqlparser/v2 v2.4.2
-	github.com/getsentry/sentry-go v0.13.0
-	github.com/cychiuae/go-dataloader v1.0.1
 )
 
 require (

--- a/graphql-server/gqlgen.yml
+++ b/graphql-server/gqlgen.yml
@@ -50,11 +50,7 @@ models:
     model: github.com/99designs/gqlgen/graphql.String
     
   ID:
-    model:
-      - github.com/99designs/gqlgen/graphql.ID
-      - github.com/99designs/gqlgen/graphql.Int
-      - github.com/99designs/gqlgen/graphql.Int64
-      - github.com/99designs/gqlgen/graphql.Int32
+    model: github.com/oursky/likedao/pkg/models.NodeID
   Int:
     model:
       - github.com/99designs/gqlgen/graphql.Int
@@ -63,6 +59,12 @@ models:
 
   Test:
     model: github.com/oursky/likedao/pkg/models.Test
+    fields:
+      id:
+        fieldName: NodeID
 
   Block:
     model: github.com/oursky/likedao/pkg/models.Block
+    fields:
+      id:
+        fieldName: NodeID

--- a/graphql-server/gqlgen.yml
+++ b/graphql-server/gqlgen.yml
@@ -46,8 +46,6 @@ autobind:
 models:
   DateTime:
     model: github.com/99designs/gqlgen/graphql.Time
-  Date:
-    model: github.com/99designs/gqlgen/graphql.String
     
   ID:
     model: github.com/oursky/likedao/pkg/models.NodeID

--- a/graphql-server/pkg/models/block.go
+++ b/graphql-server/pkg/models/block.go
@@ -16,3 +16,9 @@ type Block struct {
 	ProposerAddress string    `bun:"proposer_address,notnull"`
 	Timestamp       time.Time `bun:"timestamp,notnull"`
 }
+
+func (b Block) IsNode() {}
+
+func (b Block) NodeID() NodeID {
+	return GetNodeID(b)
+}

--- a/graphql-server/pkg/models/node.go
+++ b/graphql-server/pkg/models/node.go
@@ -1,0 +1,77 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	graphql "github.com/99designs/gqlgen/graphql"
+	gqlerrcode "github.com/99designs/gqlgen/graphql/errcode"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+var (
+	ErrInvalidNodeID = errors.New("Invalid node ID")
+)
+
+type NodeID struct {
+	EntityType string
+	ID         string
+}
+
+func (nodeID NodeID) String() string {
+	return fmt.Sprintf("%s_%s", nodeID.EntityType, nodeID.ID)
+}
+
+func ParseNodeID(nodeID string) (NodeID, error) {
+	parts := strings.Split(nodeID, "_")
+	if len(parts) != 2 {
+		return NodeID{}, ErrInvalidNodeID
+	}
+	return NodeID{
+		EntityType: parts[0],
+		ID:         strings.ToLower(parts[1]),
+	}, nil
+}
+
+func ExtractObjectIDs(nodeIDs []NodeID) []string {
+	objectIDs := make([]string, 0, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
+		objectIDs = append(objectIDs, nodeID.ID)
+	}
+	return objectIDs
+}
+
+// MarshalNodeID is used by gqlgen to write ID type to output.
+func MarshalNodeID(nodeID NodeID) graphql.Marshaler {
+	empty := NodeID{}
+	if nodeID == empty {
+		return graphql.Null
+	}
+
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, err := io.WriteString(w, strconv.Quote(nodeID.String()))
+		if err != nil {
+			panic(err)
+		}
+	})
+}
+
+// UnmarshalNodeID is used by gqlgen to read ID from input.
+func UnmarshalNodeID(v interface{}) (NodeID, error) {
+	if tmpStr, ok := v.(string); ok {
+		nid, err := ParseNodeID(tmpStr)
+		if err != nil {
+			gqlerr := gqlerror.Errorf(`invalid node ID "%s"`, tmpStr)
+			gqlerrcode.Set(gqlerr, gqlerrcode.ValidationFailed)
+			return NodeID{}, gqlerr
+		}
+
+		return nid, nil
+	}
+	gqlerr := gqlerror.Errorf("unable to decode Node ID")
+	gqlerrcode.Set(gqlerr, gqlerrcode.ValidationFailed)
+	return NodeID{}, gqlerr
+}

--- a/graphql-server/pkg/models/node_type.go
+++ b/graphql-server/pkg/models/node_type.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func GetNodeID(obj interface{}) NodeID {
+	switch v := obj.(type) {
+	case Test:
+		return NodeID{EntityType: "test", ID: v.ID}
+	case Block:
+		return NodeID{EntityType: "block", ID: v.Hash}
+	default:
+		panic(fmt.Sprintf(
+			`unknown entity type "%s"`,
+			reflect.TypeOf(v).String(),
+		))
+	}
+
+}

--- a/graphql-server/pkg/models/test.go
+++ b/graphql-server/pkg/models/test.go
@@ -10,3 +10,9 @@ type Test struct {
 	String string `bun:"string,notnull"`
 	Int    int    `bun:"int,notnull"`
 }
+
+func (t Test) IsNode() {}
+
+func (t Test) NodeID() NodeID {
+	return GetNodeID(t)
+}

--- a/graphql-server/pkg/queries/block.go
+++ b/graphql-server/pkg/queries/block.go
@@ -2,6 +2,7 @@ package queries
 
 import (
 	"context"
+	"strings"
 
 	"github.com/oursky/likedao/pkg/models"
 	"github.com/uptrace/bun"
@@ -9,6 +10,7 @@ import (
 
 type IBlockQuery interface {
 	QueryLatestBlock() (*models.Block, error)
+	QueryBlockByHash(hash string) (*models.Block, error)
 }
 
 type BlockQuery struct {
@@ -23,6 +25,16 @@ func NewBlockQuery(ctx context.Context, session *bun.DB) IBlockQuery {
 func (q *BlockQuery) QueryLatestBlock() (*models.Block, error) {
 	block := new(models.Block)
 	err := q.session.NewSelect().Model(block).Order("timestamp DESC").Limit(1).Scan(q.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}
+
+func (q *BlockQuery) QueryBlockByHash(hash string) (*models.Block, error) {
+	block := new(models.Block)
+	err := q.session.NewSelect().Model(block).Where("hash = ?", strings.ToUpper(hash)).Scan(q.ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql-server/pkg/resolvers/block.go
+++ b/graphql-server/pkg/resolvers/block.go
@@ -17,7 +17,14 @@ func (r *queryResolver) GetLatestBlock(ctx context.Context) (*models.Block, erro
 		return nil, err
 	}
 	return res, nil
+}
 
+func (r *queryResolver) QueryBlockByHash(ctx context.Context, hash models.NodeID) (*models.Block, error) {
+	res, err := pkgContext.GetQueriesFromCtx(ctx).Block.QueryBlockByHash(hash.ID)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Query returns graphql1.QueryResolver implementation.

--- a/graphql-server/pkg/resolvers/relay.go
+++ b/graphql-server/pkg/resolvers/relay.go
@@ -14,6 +14,8 @@ func (r *queryResolver) Node(ctx context.Context, id models.NodeID) (models.Node
 	switch id.EntityType {
 	case "test":
 		return r.QueryTestByID(ctx, id)
+	case "block":
+		return r.QueryBlockByHash(ctx, id)
 	default:
 		panic(fmt.Sprintf(
 			`unknown entity type "%s"`,

--- a/graphql-server/pkg/resolvers/relay.go
+++ b/graphql-server/pkg/resolvers/relay.go
@@ -1,0 +1,23 @@
+package resolvers
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oursky/likedao/pkg/models"
+)
+
+func (r *queryResolver) Node(ctx context.Context, id models.NodeID) (models.Node, error) {
+	switch id.EntityType {
+	case "test":
+		return r.QueryTestByID(ctx, id)
+	default:
+		panic(fmt.Sprintf(
+			`unknown entity type "%s"`,
+			id.EntityType,
+		))
+	}
+}

--- a/graphql-server/pkg/resolvers/test.go
+++ b/graphql-server/pkg/resolvers/test.go
@@ -21,8 +21,8 @@ func (r *mutationResolver) CreateTest(ctx context.Context, input models.CreateTe
 	return res, nil
 }
 
-func (r *queryResolver) QueryTestByID(ctx context.Context, id string) (*models.Test, error) {
-	res, err := pkgContext.GetDataLoadersFromCtx(ctx).Test.Load(id)
+func (r *queryResolver) QueryTestByID(ctx context.Context, id models.NodeID) (*models.Test, error) {
+	res, err := pkgContext.GetDataLoadersFromCtx(ctx).Test.Load(id.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -30,8 +30,9 @@ func (r *queryResolver) QueryTestByID(ctx context.Context, id string) (*models.T
 	return res, nil
 }
 
-func (r *queryResolver) QueryTestsByIds(ctx context.Context, ids []string) ([]*models.Test, error) {
-	res, errs := pkgContext.GetDataLoadersFromCtx(ctx).Test.LoadAll(ids)
+func (r *queryResolver) QueryTestsByIds(ctx context.Context, ids []models.NodeID) ([]*models.Test, error) {
+	objIds := models.ExtractObjectIDs(ids)
+	res, errs := pkgContext.GetDataLoadersFromCtx(ctx).Test.LoadAll(objIds)
 
 	for _, err := range errs {
 		if err != nil {

--- a/graphql-server/pkg/resolvers/test.go
+++ b/graphql-server/pkg/resolvers/test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/oursky/likedao/pkg/models"
 )
 
-func (r *mutationResolver) CreateTest(ctx context.Context, input models.CreateTest) (string, error) {
+func (r *mutationResolver) CreateTest(ctx context.Context, input models.CreateTest) (*models.Test, error) {
 	res, err := pkgContext.GetMutatorsFromCtx(ctx).Test.CreateTest(input.String, input.Int)
 
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return res.ID, nil
+	return res, nil
 }
 
 func (r *queryResolver) QueryTestByID(ctx context.Context, id string) (*models.Test, error) {


### PR DESCRIPTION
- Implemented standard node id interface
- Specify Block and Test object ID as NodeID
- Updated createTest mutation to return whole object


refs #29 