### PR TITLE
Add deployment tag to templates

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -2,13 +2,17 @@ BUILD_TAG ?= git-$(shell git rev-parse --short=8 HEAD)
 APP_NAME := likedao
 NAMESPACE ?=
 VALUES ?=
-GENESIS_URL ?= 
+GENESIS_URL ?=
+CHAIN_TAG ?=
+
+DEPLOYMENT_NAME := $(APP_NAME)-$(CHAIN_TAG)
 
 .PHONY: .checkenv
 .checkenv:
 	@test $${GENESIS_URL?Please set argument GENESIS_URL}
 	@test $${NAMESPACE?Please set argument NAMESPACE}
 	@test $${VALUES?Please set argument VALUES}
+	@test $${CHAIN_TAG?Please set argument CHAIN_TAG}
 
 .PHONY: download-genesis
 download-genesis:
@@ -25,4 +29,4 @@ make-deployment-assets:
 
 .PHONY: deploy
 deploy: .checkenv download-genesis
-	helm upgrade $(APP_NAME) $(APP_NAME) --namespace $(NAMESPACE) --values $(VALUES) --set buildTag=$(BUILD_TAG) --install
+	helm upgrade $(DEPLOYMENT_NAME) $(APP_NAME) --namespace $(NAMESPACE) --values $(VALUES) --set buildTag=$(BUILD_TAG) --set deploymentTag=$(CHAIN_TAG) --install

--- a/deploy/likedao/templates/bdjuno.yaml
+++ b/deploy/likedao/templates/bdjuno.yaml
@@ -1,18 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: bdjuno
+  name: bdjuno-{{ .Values.deploymentTag }}
   labels:
-    app: bdjuno
+    app: bdjuno-{{ .Values.deploymentTag }}
+    app.kubernetes.io/name: bdjuno-{{ .Values.deploymentTag }}
+    app.kubernetes.io/instance: bdjuno-{{ .Values.deploymentTag }}
 spec:
   selector:
     matchLabels:
-      app: bdjuno
+      app: bdjuno-{{ .Values.deploymentTag }}
   replicas: 1
   template:
     metadata:
       labels:
-        app: bdjuno
+        app: bdjuno-{{ .Values.deploymentTag }}
     spec:
       restartPolicy: Always
       containers:
@@ -20,18 +22,18 @@ spec:
           image: {{ .Values.bdjuno.imageName }}:{{ .Values.buildTag }}
           command: ["bdjuno", "start", "--home", "/bdjuno/.bdjuno"]
           volumeMounts:
-            - name: bdjuno-config
+            - name: bdjuno-config-{{ .Values.deploymentTag }}
               mountPath: /bdjuno/.bdjuno/config.yaml
               subPath: config.yaml
       volumes:
-        - name: bdjuno-config
+        - name: bdjuno-config-{{ .Values.deploymentTag }}
           configMap:
-            name: bdjuno-config
+            name: bdjuno-config-{{ .Values.deploymentTag }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: bdjuno-config
+  name: bdjuno-config-{{ .Values.deploymentTag }}
 data:
   config.yaml: |-
 {{ .Files.Get "static/bdjuno.config.yaml" | indent 4 }}

--- a/deploy/likedao/templates/graphql-server.yaml
+++ b/deploy/likedao/templates/graphql-server.yaml
@@ -2,33 +2,35 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: graphql-server
-  name: graphql-server
+    app: graphql-server-{{ .Values.deploymentTag }}
+    app.kubernetes.io/name: graphql-server-{{ .Values.deploymentTag }}
+    app.kubernetes.io/instance: graphql-server-{{ .Values.deploymentTag }}
+  name: graphql-server-{{ .Values.deploymentTag }}
 spec:
   ports:
     - port: 80
       protocol: TCP
       targetPort: 8080
   selector:
-    app: graphql-server
+    app: graphql-server-{{ .Values.deploymentTag }}
   sessionAffinity: None
   type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: graphql-server
+  name: graphql-server-{{ .Values.deploymentTag }}
   labels:
-    app: graphql-server
+    app: graphql-server-{{ .Values.deploymentTag }}
 spec:
   selector:
     matchLabels:
-      app: graphql-server
+      app: graphql-server-{{ .Values.deploymentTag }}
   replicas: 1
   template:
     metadata:
       labels:
-        app: graphql-server
+        app: graphql-server-{{ .Values.deploymentTag }}
     spec:
       restartPolicy: Always
       containers:
@@ -43,32 +45,32 @@ spec:
             - name: GRAPHQL_SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: graphql-server-config
+                  name: graphql-server-config-{{ .Values.deploymentTag }}
                   key: GRAPHQL_SENTRY_DSN
             - name: GRAPHQL_SENTRY_ENVIRONMENT
               valueFrom:
                 secretKeyRef:
-                  name: graphql-server-config
+                  name: graphql-server-config-{{ .Values.deploymentTag }}
                   key: GRAPHQL_SENTRY_ENVIRONMENT
             - name: SERVER_DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: graphql-server-config
+                  name: graphql-server-config-{{ .Values.deploymentTag }}
                   key: SERVER_DATABASE_URL
             - name: BDJUNO_DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: graphql-server-config
+                  name: graphql-server-config-{{ .Values.deploymentTag }}
                   key: BDJUNO_DATABASE_URL
             - name: SERVER_DATABASE_SCHEMA
               valueFrom:
                 secretKeyRef:
-                  name: graphql-server-config
+                  name: graphql-server-config-{{ .Values.deploymentTag }}
                   key: SERVER_DATABASE_SCHEMA
             - name: BDJUNO_DATABASE_SCHEMA
               valueFrom:
                 secretKeyRef:
-                  name: graphql-server-config
+                  name: graphql-server-config-{{ .Values.deploymentTag }}
                   key: BDJUNO_DATABASE_SCHEMA
             - name: SERVER_DATABASE_POOL_SIZE
               value: {{ .Values.graphqlServer.serverDatabase.poolSize | quote }}
@@ -96,7 +98,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: graphql-server-config
+  name: graphql-server-config-{{ .Values.deploymentTag }}
 type: Opaque
 data:
   SERVER_DATABASE_URL: {{ .Values.graphqlServer.serverDatabase.url | b64enc }}

--- a/deploy/likedao/templates/ingress.yaml
+++ b/deploy/likedao/templates/ingress.yaml
@@ -2,8 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    app: likedao
-  name: likedao
+    app: likedao-{{ .Values.deploymentTag }}
+  name: likedao-{{ .Values.deploymentTag }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
     kubernetes.io/tls-acme: "true"

--- a/deploy/likedao/templates/react-app.yaml
+++ b/deploy/likedao/templates/react-app.yaml
@@ -2,33 +2,33 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: react-app
-  name: react-app
+    app: react-app-{{ .Values.deploymentTag }}
+  name: react-app-{{ .Values.deploymentTag }}
 spec:
   ports:
     - port: 80
       protocol: TCP
       targetPort: 80
   selector:
-    app: react-app
+    app: react-app-{{ .Values.deploymentTag }}
   sessionAffinity: None
   type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: react-app
+  name: react-app-{{ .Values.deploymentTag }}
   labels:
-    app: react-app
+    app: react-app-{{ .Values.deploymentTag }}
 spec:
   selector:
     matchLabels:
-      app: react-app
+      app: react-app-{{ .Values.deploymentTag }}
   replicas: 1
   template:
     metadata:
       labels:
-        app: react-app
+        app: react-app-{{ .Values.deploymentTag }}
     spec:
       restartPolicy: Always
       containers:
@@ -37,10 +37,10 @@ spec:
           ports:
             - containerPort: 80
           volumeMounts:
-            - name: react-app-nginx-conf
+            - name: react-app-nginx-conf-{{ .Values.deploymentTag }}
               mountPath: /etc/nginx/conf.d/nginx.conf
               subPath: nginx.conf
-            - name: react-app-config
+            - name: react-app-config-{{ .Values.deploymentTag }}
               mountPath: /usr/share/config/config.js
               subPath: config.js
           readinessProbe:
@@ -62,17 +62,17 @@ spec:
             failureThreshold: 3
             timeoutSeconds: 1
       volumes:
-        - name: react-app-nginx-conf
+        - name: react-app-nginx-conf-{{ .Values.deploymentTag }}
           configMap:
-            name: react-app-nginx-conf
-        - name: react-app-config
+            name: react-app-nginx-conf-{{ .Values.deploymentTag }}
+        - name: react-app-config-{{ .Values.deploymentTag }}
           configMap:
-            name: react-app-config
+            name: react-app-config-{{ .Values.deploymentTag }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: react-app-nginx-conf
+  name: react-app-nginx-conf-{{ .Values.deploymentTag }}
 data:
   nginx.conf: |-
 {{ .Files.Get "static/react-app.nginx.conf" | indent 4 }}
@@ -80,7 +80,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: react-app-config
+  name: react-app-config-{{ .Values.deploymentTag }}
 data:
   config.js: |-
 {{ .Files.Get "static/react-app.config.js" | indent 4 }}

--- a/deploy/likedao/templates/server-database-migration.yaml
+++ b/deploy/likedao/templates/server-database-migration.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: database-migration
+  name: database-migration-{{ .Values.deploymentTag }}
   annotations:
     "helm.sh/hook": "pre-upgrade,post-install"
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -23,19 +23,19 @@ spec:
             - name: SERVER_DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: database-migration-config
+                  name: database-migration-config-{{ .Values.deploymentTag }}
                   key: SERVER_DATABASE_URL
             - name: SERVER_DATABASE_SCHEMA
               valueFrom:
                 secretKeyRef:
-                  name: database-migration-config
+                  name: database-migration-config-{{ .Values.deploymentTag }}
                   key: SERVER_DATABASE_SCHEMA
       restartPolicy: OnFailure
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: database-migration-config
+  name: database-migration-config-{{ .Values.deploymentTag }}
 type: Opaque
 data:
   SERVER_DATABASE_URL: {{ .Values.graphqlServer.serverDatabase.url | b64enc }}


### PR DESCRIPTION
## Features

- Added deployment tag to the helm chart deployment so that we can have multiple deployments in the same namespace, i.e mainnet and testnet

This only handles accepting a deployment tag as a template, the deployment itself will be updated in the deployment repo.

As we are still unsure about whether we should use multiple db or use single db with multiple schemas, we might want to hold this off first

refs #45