### PR TITLE
Implement ChainHealthiness query

### DIFF
--- a/graphql-schema/chain.graphql
+++ b/graphql-schema/chain.graphql
@@ -1,0 +1,14 @@
+enum ChainStatus {
+  Online
+  Congested
+  Offline
+}
+
+type ChainHealth {
+  height: Int!
+  status: ChainStatus!
+}
+
+extend type Query {
+  chainHealth: ChainHealth!
+}

--- a/graphql-server/gqlgen.yml
+++ b/graphql-server/gqlgen.yml
@@ -66,3 +66,6 @@ models:
     fields:
       id:
         fieldName: NodeID
+
+  AverageBlockTime:
+    model: github.com/oursky/likedao/pkg/models.AverageBlockTime

--- a/graphql-server/pkg/context/context.go
+++ b/graphql-server/pkg/context/context.go
@@ -21,6 +21,7 @@ const (
 type QueryContext struct {
 	Test  queries.ITestQuery
 	Block queries.IBlockQuery
+	Chain queries.IChainQuery
 }
 
 type MutatorContext struct {
@@ -44,6 +45,7 @@ func NewRequestContext(
 	queries := QueryContext{
 		Test:  queries.NewTestQuery(ctx, serverDB),
 		Block: queries.NewBlockQuery(ctx, chainDB),
+		Chain: queries.NewChainQuery(ctx, chainDB),
 	}
 	mutators := MutatorContext{
 		Test: mutators.NewTestMutator(ctx, serverDB),

--- a/graphql-server/pkg/models/chain.go
+++ b/graphql-server/pkg/models/chain.go
@@ -1,0 +1,12 @@
+package models
+
+import (
+	"github.com/uptrace/bun"
+)
+
+type AverageBlockTime struct {
+	bun.BaseModel `bun:"table:average_block_time_per_hour"`
+
+	AverageTime float64 `bun:"average_time,notnull"`
+	Height      int     `bun:"height,notnull"`
+}

--- a/graphql-server/pkg/queries/chain.go
+++ b/graphql-server/pkg/queries/chain.go
@@ -1,0 +1,36 @@
+package queries
+
+import (
+	"context"
+
+	"github.com/oursky/likedao/pkg/models"
+	"github.com/uptrace/bun"
+)
+
+type IChainQuery interface {
+	QueryAvergeBlockTime() (*models.AverageBlockTime, error)
+}
+
+type ChainQuery struct {
+	ctx     context.Context
+	session *bun.DB
+}
+
+type QueryBlockTimeResult struct {
+	BlockTime    float64 `bun:"previous_block_time_diff"`
+	IndexerDelay float64 `bun:"latest_block_time_diff"`
+}
+
+func NewChainQuery(ctx context.Context, session *bun.DB) IChainQuery {
+	return &ChainQuery{ctx: ctx, session: session}
+}
+
+func (q *ChainQuery) QueryAvergeBlockTime() (*models.AverageBlockTime, error) {
+	averageTime := new(models.AverageBlockTime)
+	err := q.session.NewSelect().Model(averageTime).Limit(1).Scan(q.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return averageTime, nil
+}

--- a/graphql-server/pkg/resolvers/chain.go
+++ b/graphql-server/pkg/resolvers/chain.go
@@ -1,0 +1,45 @@
+package resolvers
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+	"fmt"
+
+	pkgContext "github.com/oursky/likedao/pkg/context"
+	"github.com/oursky/likedao/pkg/models"
+)
+
+func (r *queryResolver) ChainHealth(ctx context.Context) (*models.ChainHealth, error) {
+	currentBlock, err := pkgContext.GetQueriesFromCtx(ctx).Block.QueryLatestBlock()
+	if err != nil {
+		return nil, err
+	}
+	blockTimes, err := pkgContext.GetQueriesFromCtx(ctx).Chain.QueryBlockTime()
+	if err != nil {
+		return nil, err
+	}
+
+	averageBlockTime, err := pkgContext.GetQueriesFromCtx(ctx).Chain.QueryAvergeBlockTime()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("%+v\n", blockTimes.IndexerDelay)
+
+	var status models.ChainStatus
+	// If indexer misses blocks for 1 minute, it is considered as halted.
+	if blockTimes.IndexerDelay > 60 {
+		status = models.ChainStatusOffline
+		// If previous block time difference is larger than 3 average block time, it is considered as congested.
+	} else if blockTimes.BlockTime > 3*averageBlockTime.AverageTime {
+		status = models.ChainStatusCongested
+	} else {
+		status = models.ChainStatusOnline
+	}
+
+	return &models.ChainHealth{
+		Status: status,
+		Height: currentBlock.Height,
+	}, nil
+}


### PR DESCRIPTION
## Features
- Implements a query on graphql server for the chain healthiness based on the current time, average block time and the current block timestamp

refs #46 