### PR TITLE
Create dataloader for block

### DIFF
--- a/graphql-schema/block.graphql
+++ b/graphql-schema/block.graphql
@@ -9,6 +9,6 @@ type Block implements Node {
 }
 
 extend type Query {
-  getLatestBlock: Block
-  queryBlockByHash(hash: ID!): Block
+  latestBlock: Block
+  blockByID(id: ID!): Block
 }

--- a/graphql-schema/block.graphql
+++ b/graphql-schema/block.graphql
@@ -11,4 +11,5 @@ type Block implements Node {
 extend type Query {
   latestBlock: Block
   blockByID(id: ID!): Block
+  blocksByIDs(ids: [ID!]!): [Block]
 }

--- a/graphql-schema/test.graphql
+++ b/graphql-schema/test.graphql
@@ -11,7 +11,7 @@ input CreateTest {
 
 extend type Query {
   queryTestByID(id: ID!): Test
-  queryTestsByIds(ids: [ID!]!): [Test]
+  queryTestsByIDs(ids: [ID!]!): [Test]
 }
 
 extend type Mutation {

--- a/graphql-server/pkg/context/context.go
+++ b/graphql-server/pkg/context/context.go
@@ -35,7 +35,8 @@ type MutatorContext struct {
 }
 
 type DataLoaderContext struct {
-	Test dataloaders.TestDataloader
+	Test  dataloaders.TestDataloader
+	Block dataloaders.BlockDataloader
 }
 
 type DatabaseContext struct {
@@ -62,7 +63,8 @@ func NewRequestContext(
 		Test: mutators.NewTestMutator(ctx, serverDB),
 	}
 	dataLoaders := DataLoaderContext{
-		Test: dataloaders.NewTestDataloader(queries.Test),
+		Test:  dataloaders.NewTestDataloader(queries.Test),
+		Block: dataloaders.NewBlockDataloader(queries.Block),
 	}
 
 	databases := DatabaseContext{

--- a/graphql-server/pkg/dataloaders/block.go
+++ b/graphql-server/pkg/dataloaders/block.go
@@ -1,0 +1,32 @@
+package dataloaders
+
+import (
+	"time"
+
+	godataloader "github.com/cychiuae/go-dataloader"
+	"github.com/oursky/likedao/pkg/models"
+	"github.com/oursky/likedao/pkg/queries"
+)
+
+type BlockDataloader interface {
+	Load(id string) (*models.Block, error)
+	LoadAll(ids []string) ([]*models.Block, []error)
+}
+
+func NewBlockDataloader(blockQuery queries.IBlockQuery) BlockDataloader {
+	return godataloader.NewDataLoader(godataloader.DataLoaderConfig[string, *models.Block]{
+		Fetch: func(blockHashes []string) ([]*models.Block, []error) {
+			blocks, err := blockQuery.QueryBlocksByHashes(blockHashes)
+			if err != nil {
+				errors := make([]error, 0, len(blockHashes))
+				for range blockHashes {
+					errors = append(errors, err)
+				}
+				return nil, errors
+			}
+			return blocks, nil
+		},
+		MaxBatch: 1000,
+		Wait:     20 * time.Millisecond,
+	})
+}

--- a/graphql-server/pkg/queries/block.go
+++ b/graphql-server/pkg/queries/block.go
@@ -5,12 +5,14 @@ import (
 	"strings"
 
 	"github.com/oursky/likedao/pkg/models"
+	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
 )
 
 type IBlockQuery interface {
 	QueryLatestBlock() (*models.Block, error)
 	QueryBlockByHash(hash string) (*models.Block, error)
+	QueryBlocksByHashes(hashes []string) ([]*models.Block, error)
 }
 
 type BlockQuery struct {
@@ -40,4 +42,32 @@ func (q *BlockQuery) QueryBlockByHash(hash string) (*models.Block, error) {
 	}
 
 	return block, nil
+}
+
+func (q *BlockQuery) QueryBlocksByHashes(hashes []string) ([]*models.Block, error) {
+	blocks := make([]*models.Block, 0, len(hashes))
+	uppercasedHashes := make([]string, 0, len(hashes))
+	for _, hash := range hashes {
+		uppercasedHashes = append(uppercasedHashes, strings.ToUpper(hash))
+	}
+	if err := q.session.NewSelect().Model(&blocks).Where("hash IN (?)", bun.In(uppercasedHashes)).Scan(q.ctx); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	result := make([]*models.Block, 0, len(blocks))
+	hashToBlock := make(map[string]models.Block, len(blocks))
+	for _, block := range blocks {
+		hashToBlock[block.Hash] = *block
+	}
+
+	for _, hash := range uppercasedHashes {
+		block, exists := hashToBlock[hash]
+		if exists {
+			result = append(result, &block)
+		} else {
+			result = append(result, nil)
+		}
+	}
+
+	return result, nil
 }

--- a/graphql-server/pkg/resolvers/block.go
+++ b/graphql-server/pkg/resolvers/block.go
@@ -11,7 +11,7 @@ import (
 	"github.com/oursky/likedao/pkg/models"
 )
 
-func (r *queryResolver) GetLatestBlock(ctx context.Context) (*models.Block, error) {
+func (r *queryResolver) LatestBlock(ctx context.Context) (*models.Block, error) {
 	res, err := pkgContext.GetQueriesFromCtx(ctx).Block.QueryLatestBlock()
 	if err != nil {
 		return nil, err
@@ -19,8 +19,8 @@ func (r *queryResolver) GetLatestBlock(ctx context.Context) (*models.Block, erro
 	return res, nil
 }
 
-func (r *queryResolver) QueryBlockByHash(ctx context.Context, hash models.NodeID) (*models.Block, error) {
-	res, err := pkgContext.GetQueriesFromCtx(ctx).Block.QueryBlockByHash(hash.ID)
+func (r *queryResolver) BlockByID(ctx context.Context, id models.NodeID) (*models.Block, error) {
+	res, err := pkgContext.GetQueriesFromCtx(ctx).Block.QueryBlockByHash(id.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql-server/pkg/resolvers/block.go
+++ b/graphql-server/pkg/resolvers/block.go
@@ -20,10 +20,23 @@ func (r *queryResolver) LatestBlock(ctx context.Context) (*models.Block, error) 
 }
 
 func (r *queryResolver) BlockByID(ctx context.Context, id models.NodeID) (*models.Block, error) {
-	res, err := pkgContext.GetQueriesFromCtx(ctx).Block.QueryBlockByHash(id.ID)
+	res, err := pkgContext.GetDataLoadersFromCtx(ctx).Block.Load(id.ID)
 	if err != nil {
 		return nil, err
 	}
+	return res, nil
+}
+
+func (r *queryResolver) BlocksByIDs(ctx context.Context, ids []models.NodeID) ([]*models.Block, error) {
+	blockHashes := models.ExtractObjectIDs(ids)
+	res, errs := pkgContext.GetDataLoadersFromCtx(ctx).Block.LoadAll(blockHashes)
+
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return res, nil
 }
 

--- a/graphql-server/pkg/resolvers/relay.go
+++ b/graphql-server/pkg/resolvers/relay.go
@@ -15,7 +15,7 @@ func (r *queryResolver) Node(ctx context.Context, id models.NodeID) (models.Node
 	case "test":
 		return r.QueryTestByID(ctx, id)
 	case "block":
-		return r.QueryBlockByHash(ctx, id)
+		return r.BlockByID(ctx, id)
 	default:
 		panic(fmt.Sprintf(
 			`unknown entity type "%s"`,

--- a/graphql-server/pkg/resolvers/test.go
+++ b/graphql-server/pkg/resolvers/test.go
@@ -30,7 +30,7 @@ func (r *queryResolver) QueryTestByID(ctx context.Context, id models.NodeID) (*m
 	return res, nil
 }
 
-func (r *queryResolver) QueryTestsByIds(ctx context.Context, ids []models.NodeID) ([]*models.Test, error) {
+func (r *queryResolver) QueryTestsByIDs(ctx context.Context, ids []models.NodeID) ([]*models.Test, error) {
 	objIds := models.ExtractObjectIDs(ids)
 	res, errs := pkgContext.GetDataLoadersFromCtx(ctx).Test.LoadAll(objIds)
 

--- a/react-app/src/components/DummyScreen/DummyScreen.graphql
+++ b/react-app/src/components/DummyScreen/DummyScreen.graphql
@@ -1,5 +1,5 @@
 query testQuery {
-  getLatestBlock {
+  latestBlock {
     height
   }
 }

--- a/react-app/src/components/DummyScreen/DummyScreen.tsx
+++ b/react-app/src/components/DummyScreen/DummyScreen.tsx
@@ -69,7 +69,7 @@ const DummyScreen: React.FC = () => {
         <LocalizedText messageID="App.title" />
 
         <h1>
-          Block Height: <span>{data?.getLatestBlock?.height ?? -1}</span>
+          Block Height: <span>{data?.latestBlock?.height ?? -1}</span>
         </h1>
       </div>
       <div className={cn("flex", "flex-col", "gap-y-5")}>


### PR DESCRIPTION
## Features
- Unify query names to use ID
- Created batch query for block object
- Create batch graphql query for block object 

~~## Note: Chain healthiness uses some of the block queries so i will probably rebase either of the PRs after one of them is merged.~~ Done

refs #52 