### PR TITLE
Temporary hide reinvest button

### DIFF
--- a/react-app/src/components/AppSideBar/UserInfoPanel.tsx
+++ b/react-app/src/components/AppSideBar/UserInfoPanel.tsx
@@ -24,14 +24,8 @@ interface UserInfoPanelProps {
   onClickReinvest: () => void;
 }
 const UserInfoPanel: React.FC<UserInfoPanelProps> = (props) => {
-  const {
-    userInfo,
-    className,
-    onClickSend,
-    onClickReceive,
-    onClickReward,
-    onClickReinvest,
-  } = props;
+  const { userInfo, className, onClickSend, onClickReceive, onClickReward } =
+    props;
   const { coinDenom } = Config.chainInfo.currency;
   const { translate } = useLocale();
 
@@ -100,12 +94,13 @@ const UserInfoPanel: React.FC<UserInfoPanelProps> = (props) => {
           labelId="UserInfoPanel.shortcuts.rewards"
           onClick={onClickReward}
         />
+        {/* TODO: Handle reinvest in later stages
         <ShortcutButton
           className={cn("flex-1")}
           icon={IconType.Reinvest}
           labelId="UserInfoPanel.shortcuts.reinvest"
           onClick={onClickReinvest}
-        />
+        /> */}
       </div>
     </div>
   );


### PR DESCRIPTION
## Features
- Temporarily hides reinvest button from UserInfoPanel

## Screenshots 
|Desktop | Mobile |
|--------|--------|
|![Screenshot 2022-06-09 at 2 08 06 PM](https://user-images.githubusercontent.com/18374475/172776673-e539b9ab-a4c7-42c4-bc38-f02b07047377.png)|![Screenshot 2022-06-09 at 2 08 17 PM](https://user-images.githubusercontent.com/18374475/172776686-44d64943-30dc-426f-94e1-c1def5d9a821.png)|




refs #9 