### PR TITLE
Lower proposal description character limit and fix markdown preview list style

### DIFF
--- a/react-app/src/components/forms/CreateProposalForm/CreateProposalFormModel.ts
+++ b/react-app/src/components/forms/CreateProposalForm/CreateProposalFormModel.ts
@@ -34,13 +34,14 @@ export const useCreateProposalFormModel = (): {
       },
       title: {
         required: requiredValidator,
-        // https://github.com/cosmos/cosmos-sdk/blob/55054282d2df794d9a5fe2599ea25473379ebc3d/x/gov/types/v1beta1/proposal.go#L169
+        // https://github.com/cosmos/cosmos-sdk/blob/master/x/gov/types/v1beta1/proposal.go#L169
         maxLength: maxLengthValidator(140),
       },
       description: {
         required: false,
-        // https://github.com/cosmos/cosmos-sdk/blob/55054282d2df794d9a5fe2599ea25473379ebc3d/x/gov/types/v1beta1/proposal.go#L168
-        maxLength: maxLengthValidator(10000),
+        // TODO: Change to 10000 once chain is updated to 0.45+
+        // https://github.com/cosmos/cosmos-sdk/blob/master/x/gov/types/v1beta1/proposal.go#L168
+        maxLength: maxLengthValidator(5000),
       },
     };
   }, [requiredValidator, maxLengthValidator, translate]);

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -4,6 +4,16 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Tailwind sets list-style to none which breaks markdown previewer */
+/* stylelint-disable */
+@layer base {
+  ul,
+  ol {
+    list-style: initial;
+  }
+}
+/* stylelint-enable */
+
 body {
   font-family: "Inter", sans-serif;
 }


### PR DESCRIPTION
## Features
- Temporarily lower the character limit for proposal description to fit the spec of cosmos sdk 0.44.8
- Reverted the `list-style:none` style set by tailwind base class to fix missing points from the markdown previewer

## Screenshots
<img width="886" alt="Screenshot 2022-06-10 at 1 47 03 PM" src="https://user-images.githubusercontent.com/18374475/172999052-eed47191-6063-4bf3-9e78-99ae1eb121f1.png">

refs #27 
