### PR TITLE
Implement governance params API

### DIFF
--- a/graphql-schema/gov.graphql
+++ b/graphql-schema/gov.graphql
@@ -20,5 +20,5 @@ type GovParams {
 }
 
 extend type Query {
-  getGovParams: GovParams!
+  govParams: GovParams!
 }

--- a/graphql-schema/gov.graphql
+++ b/graphql-schema/gov.graphql
@@ -1,0 +1,24 @@
+type DepositParams {
+  minDeposit: [Coin]!
+  maxDepositPeriod: Int!
+}
+
+type VotingParams {
+  votingPeriod: Int!
+}
+
+type TallyParams {
+  quorum: BigFloat!
+  threshold: BigFloat!
+  vetoThreshold: BigFloat!
+}
+
+type GovParams {
+  depositParams: DepositParams!
+  votingParams: VotingParams!
+  tallyParams: TallyParams!
+}
+
+extend type Query {
+  getGovParams: GovParams!
+}

--- a/graphql-server/gqlgen.yml
+++ b/graphql-server/gqlgen.yml
@@ -98,3 +98,11 @@ models:
   Coin:
     model: github.com/forbole/bdjuno/database/types.DbDecCoin
 
+  GovParams:
+    model: github.com/oursky/likedao/pkg/models.GovParams
+  DepositParams:
+    model: github.com/oursky/likedao/pkg/models.DepositParams
+  TallyParams:
+    model: github.com/oursky/likedao/pkg/models.TallyParams
+  VotingParams:
+    model: github.com/oursky/likedao/pkg/models.VotingParams

--- a/graphql-server/pkg/context/context.go
+++ b/graphql-server/pkg/context/context.go
@@ -29,6 +29,7 @@ type QueryContext struct {
 	StakingPool   queries.IStakingPoolQuery
 	Supply        queries.ISupplyQuery
 	Proposal      queries.IProposalQuery
+	Gov           queries.IGovQuery
 }
 
 type MutatorContext struct {
@@ -61,6 +62,7 @@ func NewRequestContext(
 		StakingPool:   queries.NewStakingPoolQuery(ctx, chainDB),
 		Supply:        queries.NewSupplyQuery(ctx, chainDB),
 		Proposal:      queries.NewProposalQuery(ctx, config, chainDB),
+		Gov:           queries.NewGovQuery(ctx, chainDB),
 	}
 	mutators := MutatorContext{
 		Test: mutators.NewTestMutator(ctx, serverDB),

--- a/graphql-server/pkg/models/gov.go
+++ b/graphql-server/pkg/models/gov.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"github.com/forbole/bdjuno/database/types"
+	"github.com/uptrace/bun"
+)
+
+type DepositParams struct {
+	MinDeposit       []*types.DbDecCoin `json:"min_deposit"`
+	MaxDepositPeriod int64              `json:"max_deposit_period"`
+}
+
+type TallyParams struct {
+	Quorum        string `json:"quorum"`
+	Threshold     string `json:"threshold"`
+	VetoThreshold string `json:"veto_threshold"`
+}
+
+type VotingParams struct {
+	VotingPeriod int64 `json:"voting_period"`
+}
+
+type GovParams struct {
+	bun.BaseModel `bun:"table:gov_params"`
+
+	OneRowID      bool          `bun:"column:one_row_id"`
+	DepositParams DepositParams `bun:"column:deposit_params,type:jsonb"`
+	TallyParams   TallyParams   `bun:"column:tally_params,type:jsonb"`
+	VotingParams  VotingParams  `bun:"column:voting_params,type:jsonb"`
+}

--- a/graphql-server/pkg/models/gov.go
+++ b/graphql-server/pkg/models/gov.go
@@ -23,7 +23,6 @@ type VotingParams struct {
 type GovParams struct {
 	bun.BaseModel `bun:"table:gov_params"`
 
-	OneRowID      bool          `bun:"column:one_row_id"`
 	DepositParams DepositParams `bun:"column:deposit_params,type:jsonb"`
 	TallyParams   TallyParams   `bun:"column:tally_params,type:jsonb"`
 	VotingParams  VotingParams  `bun:"column:voting_params,type:jsonb"`

--- a/graphql-server/pkg/queries/gov.go
+++ b/graphql-server/pkg/queries/gov.go
@@ -1,0 +1,34 @@
+package queries
+
+import (
+	"context"
+
+	"github.com/oursky/likedao/pkg/config"
+	"github.com/oursky/likedao/pkg/models"
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+type IGovQuery interface {
+	QueryGovParams() (*models.GovParams, error)
+}
+
+type GovQuery struct {
+	ctx     context.Context
+	config  config.Config
+	session *bun.DB
+}
+
+func NewGovQuery(ctx context.Context, session *bun.DB) IGovQuery {
+	return &GovQuery{ctx: ctx, session: session}
+}
+
+func (q *GovQuery) QueryGovParams() (*models.GovParams, error) {
+	govParams := new(models.GovParams)
+	err := q.session.NewSelect().Model(govParams).Where("one_row_id = true").Scan(q.ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return govParams, nil
+}

--- a/graphql-server/pkg/queries/gov.go
+++ b/graphql-server/pkg/queries/gov.go
@@ -3,7 +3,6 @@ package queries
 import (
 	"context"
 
-	"github.com/oursky/likedao/pkg/config"
 	"github.com/oursky/likedao/pkg/models"
 	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
@@ -15,7 +14,6 @@ type IGovQuery interface {
 
 type GovQuery struct {
 	ctx     context.Context
-	config  config.Config
 	session *bun.DB
 }
 
@@ -25,7 +23,7 @@ func NewGovQuery(ctx context.Context, session *bun.DB) IGovQuery {
 
 func (q *GovQuery) QueryGovParams() (*models.GovParams, error) {
 	govParams := new(models.GovParams)
-	err := q.session.NewSelect().Model(govParams).Where("one_row_id = true").Scan(q.ctx)
+	err := q.session.NewSelect().Model(govParams).Scan(q.ctx)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/graphql-server/pkg/resolvers/gov.go
+++ b/graphql-server/pkg/resolvers/gov.go
@@ -10,7 +10,7 @@ import (
 	"github.com/oursky/likedao/pkg/models"
 )
 
-func (r *queryResolver) GetGovParams(ctx context.Context) (*models.GovParams, error) {
+func (r *queryResolver) GovParams(ctx context.Context) (*models.GovParams, error) {
 	govParams, err := pkgContext.GetQueriesFromCtx(ctx).Gov.QueryGovParams()
 	if err != nil {
 		return nil, err

--- a/graphql-server/pkg/resolvers/gov.go
+++ b/graphql-server/pkg/resolvers/gov.go
@@ -1,0 +1,19 @@
+package resolvers
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+
+	pkgContext "github.com/oursky/likedao/pkg/context"
+	"github.com/oursky/likedao/pkg/models"
+)
+
+func (r *queryResolver) GetGovParams(ctx context.Context) (*models.GovParams, error) {
+	govParams, err := pkgContext.GetQueriesFromCtx(ctx).Gov.QueryGovParams()
+	if err != nil {
+		return nil, err
+	}
+	return govParams, nil
+}


### PR DESCRIPTION
### Changes

- Implemented graphql schema, server models, query and resolvers for gov_params

#### Request
```gql
query GovParms {
  govParams {
  	__typename
    depositParams {
      __typename
      minDeposit {
        __typename
        denom
        amount
      }
      maxDepositPeriod
    }
    votingParams {
      __typename
      votingPeriod
    }
    tallyParams {
      __typename
      quorum
      threshold
      vetoThreshold
    }
  }
}
```

#### Response (TestNet)
```json
{
  "data": {
    "govParams": {
      "__typename": "GovParams",
      "depositParams": {
        "__typename": "DepositParams",
        "minDeposit": [
          {
            "__typename": "Coin",
            "denom": "nanoekil",
            "amount": "10000000"
          }
        ],
        "maxDepositPeriod": 86400000000000
      },
      "votingParams": {
        "__typename": "VotingParams",
        "votingPeriod": 86400000000000
      },
      "tallyParams": {
        "__typename": "TallyParams",
        "quorum": "0.334000000000000000",
        "threshold": "0.500000000000000000",
        "vetoThreshold": "0.334000000000000000"
      }
    }
  }
}
```

Edit: rename query `getGovParams` -> `govParams`

refs oursky/likedao#167