### PR TITLE
Refactor proposal schema & add `All` tab to proposal list

### DIFF
--- a/graphql-schema/proposal.graphql
+++ b/graphql-schema/proposal.graphql
@@ -16,7 +16,7 @@ enum ProposalStatus {
   Invalid
 }
 
-enum ProposalFilter {
+enum ProposalStatusFilter {
   Voting
   Deposit
   Passed
@@ -69,13 +69,27 @@ type ProposalTallyResult {
   outstandingOption: ProposalVoteOption
 }
 
+"""
+Filter by address's role in proposals
+or operator will be used when more than one is* field is specified
+"""
+input ProposalAddressFilter {
+  address: String!
+  isDepositor: Boolean!
+  isVoter: Boolean!
+  isSubmitter: Boolean!
+}
+
 input QueryProposalsInput {
-  # Limit
+  "Number of proposals to show in a page (limit)"
   first: Int!
-  # Offset
+  "Offset"
   after: Int!
-  filter: ProposalFilter
-  followingAddress: String
+  "Filter by proposal status"
+  status: ProposalStatusFilter
+  "filter by address's role in proposals"
+  address: ProposalAddressFilter
+  "filter by proposal title (not implemented)"
   searchTerm: String
 }
 

--- a/graphql-server/pkg/models/proposal.go
+++ b/graphql-server/pkg/models/proposal.go
@@ -36,15 +36,15 @@ func (e *ProposalStatus) UnmarshalGQL(v string) error {
 	return nil
 }
 
-func (e ProposalFilter) ToProposalStatus() ProposalStatus {
+func (e ProposalStatusFilter) ToProposalStatus() ProposalStatus {
 	switch e {
-	case ProposalFilterVoting:
+	case ProposalStatusFilterVoting:
 		return ProposalStatusVotingPeriod
-	case ProposalFilterDeposit:
+	case ProposalStatusFilterDeposit:
 		return ProposalStatusDepositPeriod
-	case ProposalFilterPassed:
+	case ProposalStatusFilterPassed:
 		return ProposalStatusPassed
-	case ProposalFilterRejected:
+	case ProposalStatusFilterRejected:
 		return ProposalStatusRejected
 	default:
 		return ProposalStatusUnspecified

--- a/graphql-server/pkg/resolvers/proposal.go
+++ b/graphql-server/pkg/resolvers/proposal.go
@@ -149,10 +149,10 @@ func (r *proposalTallyResultResolver) OutstandingOption(ctx context.Context, obj
 
 func (r *queryResolver) Proposals(ctx context.Context, input models.QueryProposalsInput) (*models.Connection[models.Proposal], error) {
 	proposalQuery := pkgContext.GetQueriesFromCtx(ctx).Proposal
-	if input.FollowingAddress != nil && *input.FollowingAddress != "" {
-		proposalQuery = proposalQuery.ScopeRelatedAddress(*input.FollowingAddress)
-	} else if input.Filter != nil {
-		proposalQuery = proposalQuery.ScopeProposalStatus((*input.Filter).ToProposalStatus())
+	if input.Address != nil && input.Address.Address != "" {
+		proposalQuery = proposalQuery.ScopeRelatedAddress(input.Address.Address)
+	} else if input.Status != nil {
+		proposalQuery = proposalQuery.ScopeProposalStatus((*input.Status).ToProposalStatus())
 	}
 
 	res, err := proposalQuery.QueryPaginatedProposals(input.First, input.After)

--- a/react-app/src/components/ProposalScreen/ProposalScreen.graphql
+++ b/react-app/src/components/ProposalScreen/ProposalScreen.graphql
@@ -22,17 +22,17 @@ fragment ProposalScreenProposal on Proposal {
 query ProposalScreenQuery(
   $first: Int!
   $after: Int!
-  $filter: ProposalFilter
-  $followingAddress: String
+  $status: ProposalStatusFilter
+  $address: ProposalAddressFilter
   $searchTerm: String
 ) {
   proposals(
     input: {
-      after: $after
-      filter: $filter
-      followingAddress: $followingAddress
-      searchTerm: $searchTerm
       first: $first
+      after: $after
+      status: $status
+      address: $address
+      searchTerm: $searchTerm
     }
   ) {
     pageInfo {

--- a/react-app/src/components/ProposalScreen/ProposalScreen.tsx
+++ b/react-app/src/components/ProposalScreen/ProposalScreen.tsx
@@ -55,7 +55,6 @@ const ProposalScreen: React.FC = () => {
   const [after, setAfter] = useState(0);
 
   const [searchParams, setSearchParams] = useSearchParams({
-    first: PROPOSAL_LIST_PAGE_SIZE.toString(),
     after: after.toString(),
     tab: defaultTabItem.value,
   });
@@ -87,7 +86,6 @@ const ProposalScreen: React.FC = () => {
 
   useEffect(() => {
     setSearchParams({
-      first: PROPOSAL_LIST_PAGE_SIZE.toString(),
       after: after.toString(),
       tab: selectedTab,
     });

--- a/react-app/src/components/ProposalScreen/ProposalScreen.tsx
+++ b/react-app/src/components/ProposalScreen/ProposalScreen.tsx
@@ -1,28 +1,24 @@
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import cn from "classnames";
-import { useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
+import { useSearchParams } from "react-router-dom";
 import { Icon, IconType } from "../common/Icons/Icons";
 import LocalizedText from "../common/Localized/LocalizedText";
 import AppButton from "../common/Buttons/AppButton";
 import AppRoutes from "../../navigation/AppRoutes";
-import {
-  isRequestStateError,
-  isRequestStateInitial,
-  isRequestStateLoaded,
-  isRequestStateLoading,
-} from "../../models/RequestState";
+import * as RequestState from "../../models/RequestState";
 import PageContoller from "../common/PageController/PageController";
 import FilterTabs, { IFilterTabItem } from "../FilterTabs/FilterTabs";
 import { ConnectionStatus, useWallet } from "../../providers/WalletProvider";
 import { useLocale } from "../../providers/AppLocaleProvider";
-import { useEffectOnce } from "../../hooks/useEffectOnce";
-import { FilterKey, useProposalsQuery } from "./ProposalScreenAPI";
+import { useProposalsQuery, FilterKey } from "./ProposalScreenAPI";
 import { ProposalList } from "./ProposalList";
 
 const PROPOSAL_LIST_PAGE_SIZE = 5;
 
-const defaultFilterItems: IFilterTabItem<FilterKey>[] = [
+type ProposalTabItem = IFilterTabItem<FilterKey>;
+
+const defaultTabItems: ProposalTabItem[] = [
   {
     label: "ProposalScreen.filters.voting",
     value: "voting",
@@ -41,75 +37,75 @@ const defaultFilterItems: IFilterTabItem<FilterKey>[] = [
   },
 ];
 
+/**
+ * Tab shown on first visit to page
+ */
+const defaultTabItem = defaultTabItems[0];
+
 const ProposalScreen: React.FC = () => {
   const wallet = useWallet();
   const { translate } = useLocale();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedTab, setSelectedTab] = useState<FilterKey>(
+    defaultTabItem.value
+  );
+  const [after, setAfter] = useState(0);
 
-  const [offset, filter, searchTerm] = useMemo(() => {
-    const pageStr = searchParams.get("page") ?? "1";
-    const filter = searchParams.get("filter") ?? "voting";
-    const search = searchParams.get("search");
+  const [searchParams, setSearchParams] = useSearchParams({
+    first: PROPOSAL_LIST_PAGE_SIZE.toString(),
+    after: after.toString(),
+    tab: defaultTabItem.value,
+  });
 
-    const page = Math.max(parseInt(pageStr, 10), 1) - 1;
+  const tabItems: ProposalTabItem[] = useMemo(() => {
+    if (wallet.status === ConnectionStatus.Connected) {
+      const followingTab = {
+        value: "following" as const,
+        label: "ProposalScreen.filters.following" as const,
+      };
+      return [...defaultTabItems, followingTab];
+    }
 
-    return [page * PROPOSAL_LIST_PAGE_SIZE, filter as FilterKey, search];
-  }, [searchParams]);
+    return defaultTabItems;
+  }, [wallet]);
 
   const { requestState, fetch } = useProposalsQuery(
-    offset,
+    after,
     PROPOSAL_LIST_PAGE_SIZE
   );
 
-  const filterItems: IFilterTabItem<FilterKey>[] = useMemo(() => {
-    if (wallet.status === ConnectionStatus.Connected) {
-      const followingTab: IFilterTabItem<FilterKey> = {
-        label: "ProposalScreen.filters.following",
-        value: "following",
-      };
-      return [...defaultFilterItems, followingTab];
-    }
+  const setPage = useCallback((after: number) => {
+    setAfter(after);
+  }, []);
 
-    return defaultFilterItems;
-  }, [wallet]);
-
-  const setPage = useCallback(
-    (offset: number) => {
-      const page = Math.floor(offset / PROPOSAL_LIST_PAGE_SIZE) + 1;
-      const params = searchParams;
-      params.set("page", page.toString());
-      setSearchParams(params);
-    },
-    [searchParams, setSearchParams]
-  );
-
-  const setFilter = useCallback(
-    (filter: FilterKey) => {
-      const params = searchParams;
-      params.set("filter", filter);
-      params.set("page", "1");
-      setSearchParams(params);
-    },
-    [setSearchParams, searchParams]
-  );
+  const handleSelectTab = useCallback((tab: FilterKey) => {
+    setSelectedTab(tab);
+  }, []);
 
   useEffect(() => {
-    const address =
-      wallet.status === ConnectionStatus.Connected
-        ? wallet.account.address
-        : undefined;
-    fetch(offset, filter, address, searchTerm ?? undefined);
-  }, [fetch, offset, filter, searchTerm, wallet]);
+    setSearchParams({
+      first: PROPOSAL_LIST_PAGE_SIZE.toString(),
+      after: after.toString(),
+      tab: selectedTab,
+    });
+    fetch({
+      first: PROPOSAL_LIST_PAGE_SIZE,
+      after,
+      tab: selectedTab,
+    });
+  }, [after, fetch, selectedTab, setSearchParams]);
 
-  useEffectOnce(
-    () => {
-      if (isRequestStateError(requestState)) {
-        toast.error(translate("ProposalScreen.requestState.error"));
-      }
-    },
-    () =>
-      isRequestStateError(requestState) || isRequestStateLoaded(requestState)
-  );
+  useEffect(() => {
+    const tab = tabItems.find((item) => item.value === searchParams.get("tab"));
+    if (tab) {
+      setSelectedTab(tab.value);
+    }
+  }, [fetch, handleSelectTab, searchParams, tabItems]);
+
+  useEffect(() => {
+    if (RequestState.isRequestStateError(requestState)) {
+      toast.error(translate("ProposalScreen.requestState.error"));
+    }
+  }, [requestState, translate]);
 
   return (
     <div
@@ -175,8 +171,8 @@ const ProposalScreen: React.FC = () => {
         </div>
         {/* TODO: Align loading state height with empty state */}
         {/* TODO: Update empty state design */}
-        {isRequestStateLoading(requestState) ||
-        isRequestStateInitial(requestState) ? (
+        {RequestState.isRequestStateLoading(requestState) ||
+        RequestState.isRequestStateInitial(requestState) ? (
           <div className={cn("h-96", "flex", "items-center", "justify-center")}>
             <Icon
               icon={IconType.Ellipse}
@@ -187,14 +183,14 @@ const ProposalScreen: React.FC = () => {
           </div>
         ) : (
           <div className={cn("mt-3.5", "flex", "flex-col", "gap-y-4")}>
-            <FilterTabs
-              tabs={filterItems}
-              selectedTab={filter}
-              onSelectTab={setFilter}
+            <FilterTabs<FilterKey>
+              tabs={tabItems}
+              selectedTab={selectedTab}
+              onSelectTab={handleSelectTab}
             />
             <ProposalList
               proposals={
-                !isRequestStateError(requestState)
+                !RequestState.isRequestStateError(requestState)
                   ? requestState.data.proposals
                   : []
               }
@@ -203,11 +199,11 @@ const ProposalScreen: React.FC = () => {
               offsetBased={true}
               pageSize={PROPOSAL_LIST_PAGE_SIZE}
               totalItems={
-                !isRequestStateError(requestState)
+                !RequestState.isRequestStateError(requestState)
                   ? requestState.data.totalCount
                   : 0
               }
-              currentOffset={offset}
+              currentOffset={after}
               onPageChange={setPage}
             />
           </div>

--- a/react-app/src/components/ProposalScreen/ProposalScreen.tsx
+++ b/react-app/src/components/ProposalScreen/ProposalScreen.tsx
@@ -101,7 +101,8 @@ const ProposalScreen: React.FC = () => {
     if (tab) {
       setSelectedTab(tab.value);
     }
-  }, [fetch, handleSelectTab, searchParams, tabItems]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (RequestState.isRequestStateError(requestState)) {

--- a/react-app/src/components/ProposalScreen/ProposalScreen.tsx
+++ b/react-app/src/components/ProposalScreen/ProposalScreen.tsx
@@ -20,6 +20,10 @@ type ProposalTabItem = IFilterTabItem<FilterKey>;
 
 const defaultTabItems: ProposalTabItem[] = [
   {
+    label: "ProposalScreen.filters.all",
+    value: "all",
+  },
+  {
     label: "ProposalScreen.filters.voting",
     value: "voting",
   },

--- a/react-app/src/components/ProposalScreen/ProposalScreenAPI.ts
+++ b/react-app/src/components/ProposalScreen/ProposalScreenAPI.ts
@@ -16,6 +16,7 @@ type ProposalFilter = Omit<
 >;
 
 export type FilterKey =
+  | "all"
   | "voting"
   | "deposit"
   | "passed"
@@ -36,6 +37,8 @@ function getFilterVariables(tab: FilterKey, address?: string): ProposalFilter {
     };
   }
   switch (tab) {
+    case "all":
+      return {};
     case "voting":
       return { status: ProposalStatusFilter.Voting };
     case "deposit":

--- a/react-app/src/i18n/translations/en.json
+++ b/react-app/src/i18n/translations/en.json
@@ -61,6 +61,7 @@
   "ProposalDetail.votingDateRange": "{from} to {to}",
   "ProposalDetail.votingDaysRemaining": "{days} days left",
   "ProposalDetail.votingPeriod": "Voting Period",
+  "ProposalScreen.filters.all": "All",
   "ProposalScreen.filters.deposit": "Deposit",
   "ProposalScreen.filters.following": "Following",
   "ProposalScreen.filters.passed": "Passed",

--- a/react-app/src/i18n/translations/zh.json
+++ b/react-app/src/i18n/translations/zh.json
@@ -61,6 +61,7 @@
   "ProposalDetail.votingDateRange": "{from} 至 {to}",
   "ProposalDetail.votingDaysRemaining": "{days} days left",
   "ProposalDetail.votingPeriod": "Voting Period",
+  "ProposalScreen.filters.all": "All",
   "ProposalScreen.filters.deposit": "Deposit",
   "ProposalScreen.filters.following": "Following",
   "ProposalScreen.filters.passed": "Passed",


### PR DESCRIPTION
### Changes

#### Backend

Redefined proposal schema for proposal history
- renamed `ProposalFilter` to `ProposalStatusFilter`
- modified `FollowingAddress` into `AddressFilter`
- added comments for documentation

#### Frontend

- created `useSearchParamsObject` hook
- added `All` tab for proposal list

refs oursky/likedao#175, oursky/likedao#180