### PR TITLE
Implement proposal history api

### DIFF
--- a/graphql-schema/proposal.graphql
+++ b/graphql-schema/proposal.graphql
@@ -47,6 +47,8 @@ type Proposal implements Node {
   tallyResult: ProposalTallyResult
   "all tally over total staking pool"
   turnout: Float
+  voteByAddress(address: String!): ProposalVote
+  depositByAddress(address: String!): ProposalDeposit
 
   reactions: [ReactionCount!]!
   myReaction: String

--- a/graphql-schema/proposal.graphql
+++ b/graphql-schema/proposal.graphql
@@ -45,6 +45,8 @@ type Proposal implements Node {
   proposerAddress: String!
   status: ProposalStatus!
   tallyResult: ProposalTallyResult
+  "all tally over total staking pool"
+  turnout: Float
 
   reactions: [ReactionCount!]!
   myReaction: String

--- a/graphql-schema/proposal.graphql
+++ b/graphql-schema/proposal.graphql
@@ -169,4 +169,5 @@ input QueryProposalDepositsInput {
 extend type Query {
   proposals(input: QueryProposalsInput!): ProposalConnection!
   proposalByID(id: ID!): Proposal
+  proposalVotesDistribution(address: String!): ProposalTallyResult!
 }

--- a/graphql-server/pkg/dataloaders/proposal.go
+++ b/graphql-server/pkg/dataloaders/proposal.go
@@ -11,6 +11,8 @@ type ProposalDataloader interface {
 	LoadAll(ids []string) ([]*models.Proposal, []error)
 	LoadProposalTallyResult(id int) (*models.ProposalTallyResult, error)
 	LoadProposalTurnout(id int) (*float64, error)
+	LoadProposalVote(key models.ProposalVoteKey) (*models.ProposalVote, error)
+	LoadProposalDeposit(key models.ProposalDepositKey) (*models.ProposalDeposit, error)
 }
 
 type ProposalLoader interface {
@@ -28,10 +30,22 @@ type ProposalTurnoutDataloader interface {
 	LoadAll(ids []int) ([]*float64, []error)
 }
 
+type ProposalVoteDataloader interface {
+	Load(key models.ProposalVoteKey) (*models.ProposalVote, error)
+	LoadAll(keys []models.ProposalVoteKey) ([]*models.ProposalVote, []error)
+}
+
+type ProposalDepositDataloader interface {
+	Load(key models.ProposalDepositKey) (*models.ProposalDeposit, error)
+	LoadAll(keys []models.ProposalDepositKey) ([]*models.ProposalDeposit, []error)
+}
+
 type IProposalDataloader struct {
 	proposalLoader            ProposalLoader
 	proposalTallyResultLoader ProposalTallyResultDataloader
 	proposalTurnoutDataloader ProposalTurnoutDataloader
+	proposalVoteLoader        ProposalVoteDataloader
+	proposalDepositLoader     ProposalDepositDataloader
 }
 
 func NewProposalDataloader(proposalQuery queries.IProposalQuery) ProposalDataloader {
@@ -83,10 +97,44 @@ func NewProposalDataloader(proposalQuery queries.IProposalQuery) ProposalDataloa
 		Wait:     DefaultWait,
 	})
 
+	proposalVoteLoader := godataloader.NewDataLoader(godataloader.DataLoaderConfig[models.ProposalVoteKey, *models.ProposalVote]{
+		MaxBatch: DefaultMaxBatch,
+		Wait:     DefaultWait,
+		Fetch: func(keys []models.ProposalVoteKey) ([]*models.ProposalVote, []error) {
+			votes, err := proposalQuery.QueryProposalVotes(keys)
+			if err != nil {
+				errors := make([]error, 0, len(keys))
+				for range keys {
+					errors = append(errors, err)
+				}
+				return nil, errors
+			}
+			return votes, nil
+		},
+	})
+
+	proposalDepositLoader := godataloader.NewDataLoader(godataloader.DataLoaderConfig[models.ProposalDepositKey, *models.ProposalDeposit]{
+		MaxBatch: DefaultMaxBatch,
+		Wait:     DefaultWait,
+		Fetch: func(keys []models.ProposalDepositKey) ([]*models.ProposalDeposit, []error) {
+			deposits, err := proposalQuery.QueryProposalDeposits(keys)
+			if err != nil {
+				errors := make([]error, 0, len(keys))
+				for range keys {
+					errors = append(errors, err)
+				}
+				return nil, errors
+			}
+			return deposits, nil
+		},
+	})
+
 	return &IProposalDataloader{
 		proposalLoader:            proposalLoader,
 		proposalTallyResultLoader: proposalTallyResultLoader,
 		proposalTurnoutDataloader: proposalTurnoutDataloader,
+		proposalVoteLoader:        proposalVoteLoader,
+		proposalDepositLoader:     proposalDepositLoader,
 	}
 }
 
@@ -104,4 +152,12 @@ func (d IProposalDataloader) LoadProposalTallyResult(id int) (*models.ProposalTa
 
 func (d IProposalDataloader) LoadProposalTurnout(id int) (*float64, error) {
 	return d.proposalTurnoutDataloader.Load(id)
+}
+
+func (d IProposalDataloader) LoadProposalVote(key models.ProposalVoteKey) (*models.ProposalVote, error) {
+	return d.proposalVoteLoader.Load(key)
+}
+
+func (d IProposalDataloader) LoadProposalDeposit(key models.ProposalDepositKey) (*models.ProposalDeposit, error) {
+	return d.proposalDepositLoader.Load(key)
 }

--- a/graphql-server/pkg/errors/errors.go
+++ b/graphql-server/pkg/errors/errors.go
@@ -17,6 +17,7 @@ const (
 	QueryError        ServerErrorCode = "QUERY_ERROR"
 	MutationError     ServerErrorCode = "MUTATION_ERROR"
 	Unauthenticated   ServerErrorCode = "UNAUTHENTICATED"
+	BadUserInput      ServerErrorCode = "BAD_USER_INPUT"
 )
 
 var defaultErrorMessage = map[ServerErrorCode]string{
@@ -27,6 +28,7 @@ var defaultErrorMessage = map[ServerErrorCode]string{
 	Unknown:           "Unknown error",
 	QueryError:        "Query error",
 	MutationError:     "Mutation error",
+	BadUserInput:      "User input error",
 }
 
 func (c ServerErrorCode) NewErrorWithDefaultMessage(ctx context.Context) *gqlerror.Error {

--- a/graphql-server/pkg/models/proposal.go
+++ b/graphql-server/pkg/models/proposal.go
@@ -226,3 +226,8 @@ type ProposalTallyResult struct {
 	NoWithVeto *bunbig.Int `bun:"column:no_with_veto,notnull"`
 	Height     int64       `bun:"column:height,notnull"`
 }
+
+type ProposalTurnout struct {
+	ProposalID int
+	Turnout    float64
+}

--- a/graphql-server/pkg/models/proposal.go
+++ b/graphql-server/pkg/models/proposal.go
@@ -224,6 +224,11 @@ func (p ProposalVote) NodeID() NodeID {
 type ProposalVoteConnection = Connection[ProposalVote]
 type ProposalVoteEdge = Edge[ProposalVote]
 
+type ProposalVoteOptionCount struct {
+	Option ProposalVoteOption
+	Count  bunbig.Int
+}
+
 type ProposalTallyResult struct {
 	bun.BaseModel `bun:"table:proposal_tally_result"`
 

--- a/graphql-server/pkg/models/proposal.go
+++ b/graphql-server/pkg/models/proposal.go
@@ -108,13 +108,17 @@ func (p Proposal) NodeID() NodeID {
 type ProposalConnection = Connection[Proposal]
 type ProposalEdge = Edge[Proposal]
 
+type ProposalDepositKey struct {
+	ProposalID int
+	Address    string
+}
 type ProposalDeposit struct {
 	bun.BaseModel `bun:"table:proposal_deposit"`
 
-	ProposalID       int               `bun:"column:proposal_id,pk"`
-	DepositorAddress string            `bun:"column:depositor_address,notnull"`
-	Amount           bdjuno.DbDecCoins `bun:"column:amount,notnull"`
-	Height           int64             `bun:"column:height,notnull"`
+	ProposalID       int                `bun:"column:proposal_id,pk"`
+	DepositorAddress string             `bun:"column:depositor_address,notnull"`
+	Amount           []bdjuno.DbDecCoin `bun:"column:amount,notnull,array"`
+	Height           int64              `bun:"column:height,notnull"`
 
 	Proposal      *Proposal      `bun:"rel:belongs-to,join:proposal_id=id"`
 	ValidatorInfo *ValidatorInfo `bun:"rel:has-one,join:depositor_address=self_delegate_address"`
@@ -164,6 +168,10 @@ func (p ProposalDeposit) NodeID() NodeID {
 type ProposalDepositConnection = Connection[ProposalDeposit]
 type ProposalDepositEdge = Edge[ProposalDeposit]
 
+type ProposalVoteKey struct {
+	ProposalID int
+	Address    string
+}
 type ProposalVote struct {
 	bun.BaseModel `bun:"table:proposal_vote"`
 

--- a/graphql-server/pkg/resolvers/proposal.go
+++ b/graphql-server/pkg/resolvers/proposal.go
@@ -51,6 +51,18 @@ func (r *proposalResolver) TallyResult(ctx context.Context, obj *models.Proposal
 	return tally, nil
 }
 
+func (r *proposalResolver) Turnout(ctx context.Context, obj *models.Proposal) (*float64, error) {
+	turnout, err := pkgContext.GetDataLoadersFromCtx(ctx).Proposal.LoadProposalTurnout(obj.ID)
+	if err != nil {
+		return nil, servererrors.QueryError.NewError(ctx, fmt.Sprintf("failed to load proposal turnout: %v", err))
+	}
+	if turnout == nil {
+		return nil, nil
+	}
+
+	return turnout, nil
+}
+
 func (r *proposalResolver) Reactions(ctx context.Context, obj *models.Proposal) ([]models.ReactionCount, error) {
 	reactionCounts, err := pkgContext.GetDataLoadersFromCtx(ctx).Reaction.LoadProposalReactionCount(obj.ID)
 	if err != nil {

--- a/graphql-server/pkg/resolvers/proposal.go
+++ b/graphql-server/pkg/resolvers/proposal.go
@@ -63,6 +63,24 @@ func (r *proposalResolver) Turnout(ctx context.Context, obj *models.Proposal) (*
 	return turnout, nil
 }
 
+func (r *proposalResolver) VoteByAddress(ctx context.Context, obj *models.Proposal, address string) (*models.ProposalVote, error) {
+	key := models.ProposalVoteKey{ProposalID: obj.ID, Address: address}
+	vote, err := pkgContext.GetDataLoadersFromCtx(ctx).Proposal.LoadProposalVote(key)
+	if err != nil {
+		return nil, err
+	}
+	return vote, nil
+}
+
+func (r *proposalResolver) DepositByAddress(ctx context.Context, obj *models.Proposal, address string) (*models.ProposalDeposit, error) {
+	key := models.ProposalDepositKey{ProposalID: obj.ID, Address: address}
+	vote, err := pkgContext.GetDataLoadersFromCtx(ctx).Proposal.LoadProposalDeposit(key)
+	if err != nil {
+		return nil, err
+	}
+	return vote, nil
+}
+
 func (r *proposalResolver) Reactions(ctx context.Context, obj *models.Proposal) ([]models.ReactionCount, error) {
 	reactionCounts, err := pkgContext.GetDataLoadersFromCtx(ctx).Reaction.LoadProposalReactionCount(obj.ID)
 	if err != nil {
@@ -308,17 +326,6 @@ func (r *proposalDepositResolver) Depositor(ctx context.Context, obj *models.Pro
 	}
 
 	return nil, nil
-}
-
-func (r *proposalDepositResolver) Amount(ctx context.Context, obj *models.ProposalDeposit) ([]types.DbDecCoin, error) {
-	coins := make([]types.DbDecCoin, 0, len(obj.Amount))
-	for _, coin := range obj.Amount {
-		coins = append(coins, types.DbDecCoin{
-			Denom:  coin.Denom,
-			Amount: coin.Amount,
-		})
-	}
-	return coins, nil
 }
 
 func (r *proposalTallyResultResolver) Yes(ctx context.Context, obj *models.ProposalTallyResult) (gql_bigint.BigInt, error) {

--- a/graphql-server/pkg/resolvers/proposal.go
+++ b/graphql-server/pkg/resolvers/proposal.go
@@ -450,6 +450,14 @@ func (r *queryResolver) ProposalByID(ctx context.Context, id models.NodeID) (*mo
 	return res, nil
 }
 
+func (r *queryResolver) ProposalVotesDistribution(ctx context.Context, address string) (*models.ProposalTallyResult, error) {
+	distribution, err := pkgContext.GetQueriesFromCtx(ctx).Proposal.QueryProposalVoteCountByAddress(address)
+	if err != nil {
+		return nil, err
+	}
+	return distribution, nil
+}
+
 // Proposal returns graphql1.ProposalResolver implementation.
 func (r *Resolver) Proposal() graphql1.ProposalResolver { return &proposalResolver{r} }
 


### PR DESCRIPTION
Note: Will conflict with oursky/likedao#186 on proposal vote model

~~depends on oursky/likedao#181~~

### Changes
- reimplemented proposal status and address filters
- implemented turnout rate field for each proposal
- implemented vote distribution of address by vote option API

### Example queries

```gql
query Proposals($address: String!) {
  proposals(
    input: {first: 12, after: 0, status: Passed, address: {address: $address, isVoter: true, isDepositor: false, isSubmitter: false}}
  ) {
    edges {
      cursor
      node {
        id
        turnout
        myVote {
          option
        }
        myDeposit {
          amount {
            denom
            amount
          }
        }
      }
    }
  }
}
```

```gql
query VoteDistribution($address: String!){
  proposalVotesDistribution(address: $address) {
    yes
    no
    abstain
    noWithVeto
  }
}
```

refs oursky/likedao#176
