### PR TITLE
Implement proposal sort by submit time API

### DIFF
--- a/graphql-schema/proposal.graphql
+++ b/graphql-schema/proposal.graphql
@@ -125,6 +125,10 @@ type ProposalDepositConnection {
   totalCount: Int!
 }
 
+input ProposalSort {
+  submitTime: Sort
+}
+
 input QueryProposalsInput {
   "Number of proposals to show in a page (limit)"
   first: Int!
@@ -136,6 +140,7 @@ input QueryProposalsInput {
   address: ProposalAddressFilter
   "filter by proposal title (not implemented)"
   searchTerm: String
+  order: ProposalSort
 }
 
 input ProposalVoteSort {

--- a/graphql-server/pkg/queries/proposal.go
+++ b/graphql-server/pkg/queries/proposal.go
@@ -17,6 +17,7 @@ type IProposalQuery interface {
 	ScopeProposalAddress(filter *models.ProposalAddressFilter) IProposalQuery
 	QueryPaginatedProposalDeposits(proposalID int, first int, after int, orderBy *models.ProposalDepositSort, excludeAddresses []string) (*Paginated[models.ProposalDeposit], error)
 	QueryPaginatedProposalVotes(proposalID int, first int, after int, orderBy *models.ProposalVoteSort, excludeAddresses []string) (*Paginated[models.ProposalVote], error)
+	ScopeProposalOrder(order *models.ProposalSort) IProposalQuery
 	QueryPaginatedProposals(first int, after int) (*Paginated[models.Proposal], error)
 	QueryProposalTallyResults(id []int) ([]*models.ProposalTallyResult, error)
 	QueryProposalByIDs(ids []string) ([]*models.Proposal, error)
@@ -34,6 +35,7 @@ type ProposalQuery struct {
 
 	scopedProposalStatus models.ProposalStatus
 	scopedAddressFilter  *models.ProposalAddressFilter
+	scopedOrder          *models.ProposalSort
 }
 
 func NewProposalQuery(ctx context.Context, config config.Config, session *bun.DB) IProposalQuery {
@@ -76,6 +78,12 @@ func (q *ProposalQuery) NewQuery() *bun.SelectQuery {
 		})
 	}
 
+	if q.scopedOrder != nil {
+		if q.scopedOrder.SubmitTime != nil {
+			query = query.Order(fmt.Sprintf("submit_time %s", q.scopedOrder.SubmitTime))
+		}
+	}
+
 	return query
 }
 
@@ -88,6 +96,12 @@ func (q *ProposalQuery) ScopeProposalStatus(status models.ProposalStatus) IPropo
 func (q *ProposalQuery) ScopeProposalAddress(filter *models.ProposalAddressFilter) IProposalQuery {
 	var newQuery = *q
 	newQuery.scopedAddressFilter = filter
+	return &newQuery
+}
+
+func (q *ProposalQuery) ScopeProposalOrder(order *models.ProposalSort) IProposalQuery {
+	var newQuery = *q
+	newQuery.scopedOrder = order
 	return &newQuery
 }
 

--- a/graphql-server/pkg/resolvers/proposal.go
+++ b/graphql-server/pkg/resolvers/proposal.go
@@ -422,6 +422,10 @@ func (r *queryResolver) Proposals(ctx context.Context, input models.QueryProposa
 		proposalQuery = proposalQuery.ScopeProposalStatus((*input.Status).ToProposalStatus())
 	}
 
+	if input.Order != nil {
+		proposalQuery = proposalQuery.ScopeProposalOrder(input.Order)
+	}
+
 	res, err := proposalQuery.QueryPaginatedProposals(input.First, input.After)
 	if err != nil {
 		return nil, servererrors.QueryError.NewError(ctx, fmt.Sprintf("failed to load proposals: %v", err))


### PR DESCRIPTION
depends on oursky/likedao#188

### Sample Query

```gql
query Proposals {
  proposals(
    input: {first: 12, after: 0, order: { submitTime: ASC }}
  ) {
    edges {
      cursor
      node {
        proposalId
        submitTime
      }
    }
  }
}
```

refs oursky/likedao#176
