### PR TITLE
Fix proposal detail screen fetch error

### DIFF
--- a/graphql-server/pkg/queries/proposal.go
+++ b/graphql-server/pkg/queries/proposal.go
@@ -166,7 +166,17 @@ func (q *ProposalQuery) QueryProposalDepositTotal(id int, denom string) (bunbig.
 		Where("(deposit.coin).denom = ?", denom).
 		GroupExpr("(deposit.coin).denom")
 
-	err := query.Scan(q.ctx, &res)
+	// In case there are no deposits for a proposal
+	// this happens for some reason even if min proposal deposit is positive
+	count, err := query.Count(q.ctx)
+	if err != nil {
+		return bunbig.Int{}, err
+	}
+	if count == 0 {
+		return bunbig.Int{}, nil
+	}
+
+	err = query.Scan(q.ctx, &res)
 	if err != nil {
 		return bunbig.Int{}, err
 	}


### PR DESCRIPTION
When a proposal have zero deposit, `proposalByID()` query throws an error if depositTotal is one of the fields. 

Added code to handle cases where deposit is zero. 

refs https://github.com/oursky/likedao/issues/24#issuecomment-1170741706