### PR TITLE
Fix UI clipping bug on mid size screens

### DIFF
--- a/react-app/src/components/AppScaffold/AppScaffold.tsx
+++ b/react-app/src/components/AppScaffold/AppScaffold.tsx
@@ -22,9 +22,12 @@ const AppScaffold: React.FC = () => {
         "flex-col",
         "min-h-screen",
         "justify-between",
+        "sm:justify-start",
         "w-full",
+        "sm:w-full",
+        "sm:min-w-fit",
         "sm:p-8",
-        "sm:overflow-auto",
+        "sm:overflow-x-auto",
         isMenuOpen && cn("overflow-hidden", "h-screen")
       )}
     >

--- a/react-app/src/components/AppScaffold/AppScaffold.tsx
+++ b/react-app/src/components/AppScaffold/AppScaffold.tsx
@@ -25,7 +25,7 @@ const AppScaffold: React.FC = () => {
         "sm:justify-start",
         "w-full",
         "sm:w-full",
-        "sm:min-w-fit",
+        "min-w-0",
         "sm:p-8",
         "sm:overflow-x-auto",
         isMenuOpen && cn("overflow-hidden", "h-screen")

--- a/react-app/src/components/AppSideBar/AppSideBar.tsx
+++ b/react-app/src/components/AppSideBar/AppSideBar.tsx
@@ -117,6 +117,7 @@ const AppSideBar: React.FC<AppSideBarProps> = ({
         "gap-x-4",
         "gap-y-6",
         "justify-center",
+        "sm:justify-start",
         "sm:gap-y-4",
         "sm:flex-row",
         "relative",

--- a/react-app/src/components/AppSideBar/AppSideBar.tsx
+++ b/react-app/src/components/AppSideBar/AppSideBar.tsx
@@ -206,7 +206,9 @@ const AppSideBar: React.FC<AppSideBarProps> = ({
           closeMobileMenu={onMenuClose}
         />
       </div>
-      <main className={cn("grow", "px-3", "sm:px-0")}>{children}</main>
+      <main className={cn("grow", "px-3", "min-w-0", "sm:px-0")}>
+        {children}
+      </main>
     </div>
   );
 };

--- a/react-app/src/components/CommunityStatus/CommunityStatusRegular.tsx
+++ b/react-app/src/components/CommunityStatus/CommunityStatusRegular.tsx
@@ -62,9 +62,9 @@ export const CommunityStatusRegular: React.FC<CommunityStatusRegularProps> = (
         "flex",
         "flex-col",
         "gap-y-3",
-        "sm:gap-y-0",
         "sm:gap-x-3",
         "sm:flex-row",
+        "flex-wrap",
         className
       )}
     >
@@ -80,8 +80,7 @@ export const CommunityStatusRegular: React.FC<CommunityStatusRegularProps> = (
                 "text-3xl",
                 "leading-9",
                 "font-semibold",
-                "text-gray-900",
-                "break-all"
+                "text-gray-900"
               )}
             >
               {convertBigNumberToMillifiedIntegerString(

--- a/react-app/src/components/PortfolioScreen/PortfolioPanel.tsx
+++ b/react-app/src/components/PortfolioScreen/PortfolioPanel.tsx
@@ -69,7 +69,7 @@ const CoinsAmountField: React.FC<{
   amount: BigNumber;
 }> = ({ messageID, amount }) => {
   return (
-    <div className={cn("flex", "flex-col", "mr-6")}>
+    <div>
       <p
         className={cn(
           "text-likecoin-lightgreen",
@@ -124,13 +124,21 @@ const PortfolioPanel: React.FC<PortfolioPanelProps> = ({
           />
         </h2>
       </div>
-      <div className={cn("mt-11", "mb-6", "sm:flex")}>
+      <div
+        className={cn(
+          "mt-11",
+          "mb-6",
+          "sm:flex",
+          "sm:min-w-0",
+          "overflow-x-auto"
+        )}
+      >
         <ProfilePicture
           profile={portfolio.profile}
           className={cn("mb-9", "sm:mb-0", "sm:mr-9")}
         />
 
-        <div className={cn("flex", "flex-col", "items-start")}>
+        <div className={cn("flex", "flex-col", "items-start", "w-full")}>
           <p className={cn("text-xl", "leading-6", "font-medium", "mb-3")}>
             {portfolio.profile?.dtag ?? truncateAddress(portfolio.address)}
           </p>
@@ -154,14 +162,11 @@ const PortfolioPanel: React.FC<PortfolioPanelProps> = ({
 
           <div
             className={cn(
-              "flex",
-              "flex-row",
-              "flex-wrap",
-              "justify-between",
               "mt-3",
               "w-full",
-              "gap-4",
-              "sm:gap-0"
+              "grid",
+              "grid-cols-[repeat(auto-fill,minmax(100px,1fr))]",
+              "gap-y-3"
             )}
           >
             <CoinsAmountField

--- a/react-app/src/components/SectionedTable/SectionedTable.tsx
+++ b/react-app/src/components/SectionedTable/SectionedTable.tsx
@@ -179,7 +179,7 @@ const SectionedTable: <T>(
     <div className={cn("inline-block", "min-w-full", "py-2", "align-middle")}>
       <div
         className={cn(
-          "overflow-hidden",
+          "overflow-x-auto",
           "shadow",
           "ring-1",
           "ring-black",


### PR DESCRIPTION
## Overview page fully responsive

https://user-images.githubusercontent.com/106721852/178892905-3d719c35-d78b-4ca3-9b38-ff282d22a078.mov

### Portfolio page fully responsive

https://user-images.githubusercontent.com/106721852/178893376-bb8eac86-d5f2-4325-b665-d910908db49c.mov

## No overflow for proposals with super long h1 tag

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/106721852/178893129-14420809-aa4c-414c-96ac-8b538ebe03ea.png">


refs oursky/likedao#244