### PR TITLE
Fix duplicated gov info panel error toast bug

### DIFF
--- a/react-app/src/components/GovernanceInfoPanel/GovernanceInfoPanel.tsx
+++ b/react-app/src/components/GovernanceInfoPanel/GovernanceInfoPanel.tsx
@@ -45,7 +45,9 @@ const GovernanceInfoPanel: React.FC = () => {
       const params = await govAPI.getAllParams();
       setGovParams(params);
     } catch {
-      toast.error(translate("GovernanceInfoPanel.error"));
+      toast.error(translate("GovernanceInfoPanel.error"), {
+        toastId: "governance-info-panel-error",
+      });
     }
   }, [govAPI, translate]);
 


### PR DESCRIPTION
now it only show one toast, even across different screens (ie. visit new proposal screen, then quickly navigate to overview screen -> still single toast)

<img width="350" alt="image" src="https://user-images.githubusercontent.com/106721852/178446577-1b7dc6ac-dfc7-4975-850e-9c382abff733.png">
