### PR TITLE
Show community status header

### DIFF
--- a/react-app/src/components/AppSideBar/AppSideBar.graphql
+++ b/react-app/src/components/AppSideBar/AppSideBar.graphql
@@ -1,3 +1,18 @@
+fragment AppSideBarCommunityStatus on CommunityStatus {
+  bondedRatio
+  inflation
+  communityPool {
+    denom
+    amount
+  }
+}
+
 query AppSideBarQueryAverageBlockTime {
   averageBlockTime
+}
+
+query AppSideBarQueryCommunityStatus {
+  communityStatus {
+    ...AppSideBarCommunityStatus
+  }
 }

--- a/react-app/src/components/AppSideBar/AppSideBar.tsx
+++ b/react-app/src/components/AppSideBar/AppSideBar.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import cn from "classnames";
-import { useLocation } from "react-router-dom";
+import { useLocation, useMatch } from "react-router-dom";
 import { toast } from "react-toastify";
 import IconButton from "../common/Buttons/IconButton";
 import { IconType } from "../common/Icons/Icons";
@@ -16,7 +16,12 @@ import { useTransaction } from "../../providers/TransactionProvider";
 import { useEffectOnce } from "../../hooks/useEffectOnce";
 import { useLocale } from "../../providers/AppLocaleProvider";
 import Config from "../../config/Config";
-import { useChainHealthQuery } from "./AppSideBarAPI";
+import { CommunityStatusHeader } from "../CommunityStatus/CommunityStatusHeader";
+import AppRoutes from "../../navigation/AppRoutes";
+import {
+  useChainHealthQuery,
+  useAppSideBarCommunityStatusQuery,
+} from "./AppSideBarAPI";
 import { Header } from "./Header";
 import { LoginPanel } from "./LoginPanel";
 import { UserInfoPanel } from "./UserInfoPanel";
@@ -54,6 +59,7 @@ const MenuPanel: React.FC<{
   );
 };
 
+// eslint-disable-next-line complexity
 const AppSideBar: React.FC<AppSideBarProps> = ({
   children,
   isMenuOpen,
@@ -61,11 +67,14 @@ const AppSideBar: React.FC<AppSideBarProps> = ({
   onMenuOpen,
 }) => {
   const { translate } = useLocale();
+  const hideCommunityStatusHeader = useMatch(AppRoutes.Overview);
 
   const wallet = useWallet();
   const transaction = useTransaction();
 
   const { requestState } = useChainHealthQuery();
+  const communityStatusRequestState = useAppSideBarCommunityStatusQuery();
+
   const chainId = Config.chainInfo.chainId;
 
   const toggleMobileMenuMenu = useCallback(() => {
@@ -204,9 +213,22 @@ const AppSideBar: React.FC<AppSideBarProps> = ({
           closeMobileMenu={onMenuClose}
         />
       </div>
-      <main className={cn("grow", "px-3", "min-w-0", "sm:px-0")}>
-        {children}
-      </main>
+      <div className={cn("grow", "px-3", "min-w-0", "sm:px-0")}>
+        {!hideCommunityStatusHeader && (
+          <div className="flex justify-end mb-6">
+            <CommunityStatusHeader
+              className="hidden sm:flex"
+              isLoading={!isRequestStateLoaded(communityStatusRequestState)}
+              communityStatus={
+                isRequestStateLoaded(communityStatusRequestState)
+                  ? communityStatusRequestState.data
+                  : null
+              }
+            />
+          </div>
+        )}
+        <main>{children}</main>
+      </div>
     </div>
   );
 };

--- a/react-app/src/components/AppSideBar/AppSideBarModel.ts
+++ b/react-app/src/components/AppSideBar/AppSideBarModel.ts
@@ -1,10 +1,19 @@
+import BigNumber from "bignumber.js";
+import { BigNumberCoin } from "../../models/coin";
+
 export enum ChainStatus {
   Online = "online",
   Congested = "congested",
   Halted = "halted",
 }
 
-export interface AppSideBarModel {
+export interface ChainHealth {
   latestHeight: number;
   chainStatus: ChainStatus;
+}
+
+export interface CommunityStatus {
+  inflation: BigNumber;
+  bondedRatio: BigNumber;
+  communityPool: BigNumberCoin;
 }

--- a/react-app/src/components/CommunityStatus/CommunityStatusHeader.tsx
+++ b/react-app/src/components/CommunityStatus/CommunityStatusHeader.tsx
@@ -39,8 +39,7 @@ export const CommunityStatusHeader: React.FC<CommunityStatusHeaderProps> = (
                 "text-md",
                 "leading-5",
                 "font-medium",
-                "text-black",
-                "break-all"
+                "text-black"
               )}
             >
               {convertBigNumberToLocalizedIntegerString(


### PR DESCRIPTION
- Show community status on all pages except overview page
- remove `break-all` from community status panel in community status regular 

<img width="1295" alt="image" src="https://user-images.githubusercontent.com/106721852/178458591-04650bd9-b91d-4af6-8fc3-0c57d59a1780.png">

refs oursky/likedao#228