### PR TITLE
Fix proposal detail screen breaking before going mobile view

### DIFF
--- a/react-app/src/components/ProposalDetailScreen/ProposalDetailScreen.tsx
+++ b/react-app/src/components/ProposalDetailScreen/ProposalDetailScreen.tsx
@@ -249,7 +249,6 @@ const ProposalDetailScreen: React.FC = () => {
         />
         <ProposalDescription proposal={requestState.data} />
         <ProposalData proposal={requestState.data} />
-        <Paper>Comments Placeholder</Paper>
       </div>
       {activeModal === ProposalDetailModal.Vote && (
         <VoteProposalModal

--- a/react-app/src/components/ProposalDetailScreen/ProposalHeader.tsx
+++ b/react-app/src/components/ProposalDetailScreen/ProposalHeader.tsx
@@ -225,6 +225,7 @@ const ProposalActionArea: React.FC<ProposalActionAreaProps> = (props) => {
       className={cn(
         "flex",
         "flex-col",
+        "gap-y-4",
         "sm:flex-row",
         "sm:justify-between",
         "sm:justify-center"
@@ -249,9 +250,9 @@ const ProposalActionArea: React.FC<ProposalActionAreaProps> = (props) => {
       </div>
       {proposalPeriod !== null && (
         <AppButton
-          size="regular"
+          size="extra-small"
           theme="primary"
-          className={cn("text-base", "leading-6", "font-medium")}
+          className={cn("text-base", "leading-6", "font-medium", "px-6")}
           messageID={
             proposalPeriod === ProposalPeriod.Voting
               ? "ProposalDetail.voteNow"

--- a/react-app/src/components/ProposalDetailScreen/ProposalHeader.tsx
+++ b/react-app/src/components/ProposalDetailScreen/ProposalHeader.tsx
@@ -89,26 +89,28 @@ const ProposalStatistics: React.FC<{ proposal: Proposal }> = ({ proposal }) => {
         )}
       >
         <LocalizedText messageID="ProposalDetail.votingPeriod" />
-        <p className={cn("mb-1", "text-sm", "text-center")}>
-          {votingStartTime && votingEndTime ? (
-            <LocalizedText
-              messageID="ProposalDetail.votingDateRange"
-              messageArgs={{
-                from: <UTCDatetime date={votingStartTime} />,
-                to: <UTCDatetime date={votingEndTime} />,
-              }}
-            />
-          ) : (
-            "-"
-          )}
-        </p>
 
-        <Badge color="likecoin-yellow">
-          <LocalizedText
-            messageID="ProposalDetail.votingDurationRemaining"
-            messageArgs={{ duration: remainingVotingDuration }}
-          />
-        </Badge>
+        {votingStartTime && votingEndTime ? (
+          <>
+            <p className={cn("mb-1", "text-sm", "text-center")}>
+              <LocalizedText
+                messageID="ProposalDetail.votingDateRange"
+                messageArgs={{
+                  from: <UTCDatetime date={votingStartTime} />,
+                  to: <UTCDatetime date={votingEndTime} />,
+                }}
+              />
+            </p>
+            <Badge color="likecoin-yellow">
+              <LocalizedText
+                messageID="ProposalDetail.votingDurationRemaining"
+                messageArgs={{ duration: remainingVotingDuration }}
+              />
+            </Badge>
+          </>
+        ) : (
+          <p className={cn("mb-1", "text-sm", "text-center")}>-</p>
+        )}
       </div>
       <div
         className={cn(

--- a/react-app/src/components/ProposalDetailScreen/ProposalHeader.tsx
+++ b/react-app/src/components/ProposalDetailScreen/ProposalHeader.tsx
@@ -24,23 +24,22 @@ const ProposalTitle: React.FC<{ proposal: Proposal }> = ({ proposal }) => {
   const { proposalId, title, status } = proposal;
 
   return (
-    <div>
-      <div className={cn("flex", "flex-col", "gap-x-2.5", "items-center")}>
-        <div className={cn("text-xs", "mb-4")}>#{proposalId}</div>
-        <h1
-          className={cn(
-            "text-3xl",
-            "leading-none",
-            "text-center",
-            "text-app-green",
-            "leading-9",
-            "font-medium"
-          )}
-        >
-          {title}
-        </h1>
-      </div>
-      <div className={cn("flex", "flex-col", "my-4", "items-center")}>
+    <div className={cn("flex", "flex-col", "gap-y-4", "items-center")}>
+      <div className={cn("text-xs", "mb-4")}>#{proposalId}</div>
+      <h1
+        className={cn(
+          "text-3xl",
+          "leading-none",
+          "text-center",
+          "text-app-green",
+          "leading-9",
+          "font-medium",
+          "break-all"
+        )}
+      >
+        {title}
+      </h1>
+      <div className={cn("flex", "flex-col", "items-center")}>
         <ProposalStatusBadge status={status} />
       </div>
     </div>
@@ -66,28 +65,20 @@ const ProposalStatistics: React.FC<{ proposal: Proposal }> = ({ proposal }) => {
   return (
     <div
       className={cn(
-        "flex",
-        "flex-col",
-        "items-center",
-        "justify-around",
-        "my-4",
-        "p-2",
-        "sm:flex-row",
-        "sm:items-end"
+        "p-2.5",
+        "grid",
+        "grid-rows-2",
+        "grid-cols-2",
+        "sm:grid-rows-1",
+        "sm:grid-cols-4",
+        "text-sm",
+        "leading-5",
+        "font-medium",
+        "text-center",
+        "gap-y-5"
       )}
     >
-      <div
-        className={cn(
-          "flex",
-          "flex-col",
-          "items-center",
-          "justify-end",
-          "grow",
-          "text-sm",
-          "leading-5",
-          "font-medium"
-        )}
-      >
+      <div className={cn("col-span-2", "flex", "flex-col", "items-center")}>
         <LocalizedText messageID="ProposalDetail.votingPeriod" />
 
         {votingStartTime && votingEndTime ? (
@@ -112,28 +103,13 @@ const ProposalStatistics: React.FC<{ proposal: Proposal }> = ({ proposal }) => {
           <p className={cn("mb-1", "text-sm", "text-center")}>-</p>
         )}
       </div>
-      <div
-        className={cn(
-          "flex",
-          "justify-center",
-          "items-stretch",
-          "grow",
-          "w-full",
-          "sm:w-1/2",
-          "mt-5",
-          "text-sm",
-          "leading-5",
-          "font-medium"
-        )}
-      >
-        <div className={cn("flex", "flex-col", "items-center", "grow")}>
-          <LocalizedText messageID="ProposalDetail.deposit" />
-          <p>{`${totalDepositString} ${CoinDenom}`}</p>
-        </div>
-        <div className={cn("flex", "flex-col", "items-center", "grow")}>
-          <LocalizedText messageID="ProposalDetail.turnOut" />
-          <p>{turnout != null ? `${(turnout * 100).toFixed(2)}%` : "-"}</p>
-        </div>
+      <div className={cn("flex", "flex-col", "items-center", "grow")}>
+        <LocalizedText messageID="ProposalDetail.deposit" />
+        <p>{`${totalDepositString} ${CoinDenom}`}</p>
+      </div>
+      <div className={cn("flex", "flex-col", "items-center", "grow")}>
+        <LocalizedText messageID="ProposalDetail.turnOut" />
+        <p>{turnout != null ? `${(turnout * 100).toFixed(2)}%` : "-"}</p>
       </div>
     </div>
   );
@@ -147,7 +123,6 @@ const ProposalTypeAndProposer: React.FC<{ proposal: Proposal }> = ({
   return (
     <div
       className={cn(
-        "my-4",
         "p-6",
         "bg-app-lightergrey",
         "rounded-xl",
@@ -252,17 +227,14 @@ const ProposalActionArea: React.FC<ProposalActionAreaProps> = (props) => {
         "flex-col",
         "sm:flex-row",
         "sm:justify-between",
-        "sm:justify-center",
-        "mt-4"
+        "sm:justify-center"
       )}
     >
       <div
         className={cn(
           "flex",
           "flex-row",
-          "gap-x-3",
-          "sm:mb-0",
-          "mb-3",
+          "space-x-3",
           "items-center",
           "flex-wrap",
           "gap-y-4"
@@ -324,7 +296,7 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = (props) => {
   );
 
   return (
-    <Paper>
+    <Paper className={cn("flex", "flex-col", "gap-y-4")}>
       <ProposalTitle proposal={proposal} />
       <ProposalStatistics proposal={proposal} />
       <ProposalTypeAndProposer proposal={proposal} />

--- a/react-app/src/components/TallyResultIndicator/TallyResultIndicator.tsx
+++ b/react-app/src/components/TallyResultIndicator/TallyResultIndicator.tsx
@@ -30,7 +30,13 @@ const VoteDetail: React.FC<VoteDetailProps> = (props) => {
       <div className={cn("w-1", "h-8", "rounded-2xl", colorClassName)} />
       <div className={cn("flex", "flex-col", "gap-y-1")}>
         <span
-          className={cn("text-base", "leading-5", "font-bold", "text-black")}
+          className={cn(
+            "text-base",
+            "leading-5",
+            "font-bold",
+            "text-black",
+            "break-all"
+          )}
         >
           <LocalizedText messageID={labelId} />
         </span>

--- a/react-app/src/components/reactions/ReactionList.tsx
+++ b/react-app/src/components/reactions/ReactionList.tsx
@@ -19,6 +19,10 @@ interface ReactionListProps {
 export const ReactionList: React.FC<ReactionListProps> = (props) => {
   const { items, itemTheme, onItemClick } = props;
 
+  if (items.length === 0) {
+    return null;
+  }
+
   return (
     <div className={cn("flex", "flex-row", "gap-x-3")}>
       {items.map((item, index) => (


### PR DESCRIPTION
- Hide yellow time diff badge when voting start or voting end is not available
- Added break-all to title so that it doesn't overflow when there's a long word 
- Changed statistics panel to using grid to align the positioning of the components

| Before | Now |
|-------|-------|
|<img width="1200" alt="Screenshot 2022-07-20 at 3 56 28 PM" src="https://user-images.githubusercontent.com/18374475/179928573-2e169730-d675-47a2-9426-81aaf0b5187b.png">|<img width="401" alt="Screenshot 2022-07-20 at 3 49 12 PM" src="https://user-images.githubusercontent.com/18374475/179928618-207d6c60-66d5-4309-88c1-c8954f6acd10.png">|
|<img width="591" alt="Screenshot 2022-07-20 at 3 53 32 PM" src="https://user-images.githubusercontent.com/18374475/179928692-46c9e4ec-2f5f-4c1f-8619-21e41dd103fd.png">|<img width="402" alt="Screenshot 2022-07-20 at 3 56 50 PM" src="https://user-images.githubusercontent.com/18374475/179928722-abe9509a-ce13-4f3c-beb4-36bb37bdeca3.png">|

refs oursky/likedao#296 




