### PR TITLE
Fix sentry logging for gql server

### DIFF
--- a/deploy/likedao/templates/graphql-server.yaml
+++ b/deploy/likedao/templates/graphql-server.yaml
@@ -48,10 +48,7 @@ spec:
                   name: graphql-server-config-{{ .Values.deploymentTag }}
                   key: GRAPHQL_SENTRY_DSN
             - name: GRAPHQL_SENTRY_ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: graphql-server-config-{{ .Values.deploymentTag }}
-                  key: GRAPHQL_SENTRY_ENVIRONMENT
+              value: {{ .Values.deploymentTag }}
             - name: SERVER_DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -138,6 +135,5 @@ data:
   BDJUNO_DATABASE_URL: {{ .Values.graphqlServer.bdjunoDatabase.url | b64enc }}
   BDJUNO_DATABASE_SCHEMA: {{ .Values.graphqlServer.bdjunoDatabase.schema | b64enc }}
   GRAPHQL_SENTRY_DSN: {{ .Values.graphqlServer.sentry.dsn | b64enc }}
-  GRAPHQL_SENTRY_ENVIRONMENT: {{ .Values.graphqlServer.sentry.environment | b64enc }}
   SIGNATURE_SECRET: {{ .Values.graphqlServer.session.signatureSecret | b64enc }}
   COOKIE_DOMAIN: {{ .Values.graphqlServer.session.cookieDomain | b64enc }}

--- a/deploy/likedao/templates/react-app.config.yaml
+++ b/deploy/likedao/templates/react-app.config.yaml
@@ -8,6 +8,7 @@ data:
       {{ if (.Values.reactApp.sentry).dsn }}
       sentry: {
         dsn: {{ .Values.reactApp.sentry.dsn | quote }}
+        environment: {{ .Values.deploymentTag }}
       },
       {{ else }}
       sentry: null,

--- a/deploy/likedao/values.sample.yaml
+++ b/deploy/likedao/values.sample.yaml
@@ -8,7 +8,6 @@ graphqlServer:
     sessionExpiry: 86400
   sentry:
     dsn: dsn
-    environment: graphql-server
   corsAllowOrigins: "*"
   serverDatabase:
     url: postgres://likedao:likedao@server-db/likedao?sslmode=disable

--- a/graphql-server/go.mod
+++ b/graphql-server/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/99designs/gqlgen v0.17.4
 	github.com/cychiuae/go-dataloader v1.0.1
+	github.com/evalphobia/logrus_sentry v0.8.2
 	github.com/fkgi/abnf v1.0.0
 	github.com/forbole/bdjuno v0.0.0-20211005100659-82415a54ae05
 	github.com/getsentry/sentry-go v0.13.0
@@ -27,6 +28,7 @@ require (
 	github.com/armon/go-metrics v0.3.8 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect
+	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/confio/ics23/go v0.6.6 // indirect
@@ -41,6 +43,7 @@ require (
 	github.com/enigmampc/btcutil v1.0.3-0.20200723161021-e2fb6adb2a25 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/getsentry/raven-go v0.2.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect

--- a/graphql-server/go.sum
+++ b/graphql-server/go.sum
@@ -105,6 +105,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV47EEXL8mWmRdEfGscSJ+7EgePNgt0s=
+github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -196,6 +198,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evalphobia/logrus_sentry v0.8.2 h1:dotxHq+YLZsT1Bb45bB5UQbfCh3gM/nFFetyN46VoDQ=
+github.com/evalphobia/logrus_sentry v0.8.2/go.mod h1:pKcp+vriitUqu9KiWj/VRFbRfFNUwz95/UkgG8a6MNc=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 h1:0JZ+dUmQeA8IIVUMzysrX4/AKuQwWhV2dYQuPZdvdSQ=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
@@ -218,6 +222,8 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
+github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/getsentry/sentry-go v0.13.0 h1:20dgTiUSfxRB/EhMPtxcL9ZEbM1ZdR+W/7f7NWD+xWo=
 github.com/getsentry/sentry-go v0.13.0/go.mod h1:EOsfu5ZdvKPfeHYV6pTVQnsjfp30+XA7//UooKNumH0=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/graphql-server/pkg/errors/presenter.go
+++ b/graphql-server/pkg/errors/presenter.go
@@ -33,7 +33,11 @@ func DefaultErrorPresenter(ctx context.Context, e error) *gqlerror.Error {
 	// If there is no `code` in the Extensions field, we treat this as an
 	// internal error.
 	if _, ok := err.Extensions["code"]; !ok {
+		operationCtx := graphql.GetOperationContext(ctx)
 		logging.GetLogger(ctx).
+			WithField("query", operationCtx.RawQuery).
+			WithField("variables", operationCtx.Variables).
+			WithField("operationName", operationCtx.Operation.Name).
 			WithField("path", graphql.GetPath(ctx)).
 			WithError(innerErr).
 			Errorf("Unhandled internal error: %s", innerErr)

--- a/graphql-server/pkg/errors/sentry.go
+++ b/graphql-server/pkg/errors/sentry.go
@@ -1,0 +1,19 @@
+package errors
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/oursky/likedao/pkg/logging"
+)
+
+func DefaultSentryErrorTracker(ctx context.Context, err interface{}) (userMessage error) {
+	if e, ok := err.(error); ok {
+		logging.GetLogger(ctx).
+			WithField("path", graphql.GetPath(ctx)).
+			WithError(e).
+			Errorf("Unhandled internal error: %s", e)
+	}
+
+	return graphql.DefaultRecover(ctx, err)
+}

--- a/graphql-server/pkg/handlers/server.go
+++ b/graphql-server/pkg/handlers/server.go
@@ -50,6 +50,8 @@ func GraphqlHandler(serverDB *bun.DB, chainDB *bun.DB) gin.HandlerFunc {
 	h.Use(GraphQLOperationLogger{})
 
 	h.SetErrorPresenter(errors.DefaultErrorPresenter)
+	h.SetRecoverFunc(errors.DefaultSentryErrorTracker)
+
 	return func(c *gin.Context) {
 		h.ServeHTTP(c.Writer, c.Request)
 	}


### PR DESCRIPTION
Apparently gqlgen opens a nested server where the sentry context is lost and we need to handle their errors separately.

- Added logrus hook to forward errors to sentry
- Use deployment tagName as sentry environment name

Tested with
- Errors that returns unhandled error (i.e db errors)
- Errors that crashes the server (i.e undefined gql schema syntax)

refs oursky/likedao#209 