### PR TITLE
Add tooltip to "Remind to Vote" Button if email is unavailable

### DIFF
--- a/react-app/src/components/common/Buttons/IconButton.tsx
+++ b/react-app/src/components/common/Buttons/IconButton.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from "react";
 import cn from "classnames";
-import { usePopper } from "react-popper";
 import { Icon, IconType } from "../Icons/Icons";
 import Tooltip from "../Tooltip/Tooltip";
 
@@ -18,23 +17,7 @@ interface IconButtonProps
 const IconButton: React.FC<IconButtonProps> = (props) => {
   const { icon, size, className, tooltip, onClick: onClick_, ...rest } = props;
 
-  const [showTooltip, setShowTooltip] = useState<boolean>(false);
   const [refEle, setRefEle] = useState<HTMLButtonElement | null>(null);
-  const [tooltipEle, setTooltipEle] = useState<HTMLDivElement | null>(null);
-
-  const { styles, attributes, update } = usePopper(refEle, tooltipEle, {
-    placement: "bottom",
-  });
-
-  const handleMouseEnter = useCallback(() => {
-    setShowTooltip(true);
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    update?.();
-  }, [update]);
-
-  const handleMouseLeave = useCallback(() => {
-    setShowTooltip(false);
-  }, []);
 
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -51,18 +34,15 @@ const IconButton: React.FC<IconButtonProps> = (props) => {
         className={cn("p-2", "hover:bg-gray-100", "rounded-full", className)}
         onClick={onClick}
         ref={setRefEle}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
         {...rest}
       >
         <Icon icon={icon} height={size} width={size} />
       </button>
-      {showTooltip && (
+      {tooltip && (
         <Tooltip
-          ref={setTooltipEle}
-          style={styles.popper}
           content={tooltip}
-          {...attributes.popper}
+          parentElement={refEle}
+          popperOptions={{ placement: "bottom" }}
         />
       )}
     </>

--- a/react-app/src/components/common/ColorBar/ColorBar.tsx
+++ b/react-app/src/components/common/ColorBar/ColorBar.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import cn from "classnames";
 import BigNumber from "bignumber.js";
-import { usePopper } from "react-popper";
 import { useWindowEvent } from "../../../hooks/useWindowEvent";
 import Tooltip from "../Tooltip/Tooltip";
 
@@ -48,13 +47,7 @@ const ColorBarSection: React.FC<ColorBarSectionProps> = (props) => {
     null
   );
 
-  const [showTooltip, setShowTooltip] = useState<boolean>(false);
   const [refEle, setRefEle] = useState<HTMLDivElement | null>(null);
-  const [tooltipEle, setTooltipEle] = useState<HTMLDivElement | null>(null);
-
-  const { styles, attributes, update } = usePopper(refEle, tooltipEle, {
-    placement: "bottom",
-  });
 
   const percentage = useMemo(() => {
     if (total.isZero()) {
@@ -87,18 +80,6 @@ const ColorBarSection: React.FC<ColorBarSectionProps> = (props) => {
     }
   }, [percentageEl, showPercentage]);
 
-  const handleMouseEnter = useCallback(() => {
-    if (!showPercentage) return;
-
-    setShowTooltip(true);
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    update?.();
-  }, [showPercentage, update]);
-
-  const handleMouseLeave = useCallback(() => {
-    setShowTooltip(false);
-  }, []);
-
   useEffect(() => {
     handlePercentageDisplay();
   }, [handlePercentageDisplay]);
@@ -122,8 +103,6 @@ const ColorBarSection: React.FC<ColorBarSectionProps> = (props) => {
           width: percentage,
         }}
         ref={setRefEle}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
       >
         <span
           ref={setPercentageEl}
@@ -132,15 +111,12 @@ const ColorBarSection: React.FC<ColorBarSectionProps> = (props) => {
           {percentage}
         </span>
       </div>
-      {showTooltip && (
-        <div>
-          <Tooltip
-            ref={setTooltipEle}
-            style={styles.popper}
-            content={percentage}
-            {...attributes.popper}
-          />
-        </div>
+      {showPercentage && (
+        <Tooltip
+          parentElement={refEle}
+          content={percentage}
+          popperOptions={{ placement: "bottom" }}
+        />
       )}
     </>
   );

--- a/react-app/src/components/common/Tooltip/Tooltip.tsx
+++ b/react-app/src/components/common/Tooltip/Tooltip.tsx
@@ -1,45 +1,82 @@
-import React, { Fragment } from "react";
+import React, { useCallback, useLayoutEffect, useState } from "react";
 import cn from "classnames";
 import { Transition } from "@headlessui/react";
+import { usePopper } from "react-popper";
+import { Options } from "@popperjs/core";
 
 interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
+  popperOptions?: Partial<Options>;
+  parentElement: HTMLElement | null;
+  triggerElement?: HTMLElement | null;
   content: React.ReactNode | string;
 }
 
-const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>((props, ref) => {
-  const { content, ...rest } = props;
-  return (
-    <div ref={ref} {...rest}>
-      <Transition
-        show={true}
-        static={true}
-        as={Fragment}
-        enter="transition-opacity duration-150"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-150"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <div
-          role="tooltip"
-          className={cn(
-            "bg-gray-600",
-            "text-white",
-            "text-xs",
-            "h-min",
-            "py-1",
-            "px-2",
-            "rounded-md",
-            "z-50",
-            "transition-opacity"
-          )}
-        >
-          {content}
-        </div>
-      </Transition>
-    </div>
+const Tooltip: React.FC<TooltipProps> = (props) => {
+  const { content, popperOptions, parentElement, triggerElement, ...rest } =
+    props;
+
+  const [showTooltip, setShowTooltip] = useState<boolean>(false);
+  const [tooltipEle, setTooltipEle] = useState<HTMLDivElement | null>(null);
+
+  const { styles, attributes } = usePopper(
+    parentElement,
+    tooltipEle,
+    popperOptions
   );
-});
+
+  const handleMouseEnter = useCallback(() => {
+    setShowTooltip(true);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    setShowTooltip(false);
+  }, []);
+
+  useLayoutEffect(() => {
+    const element = triggerElement ?? parentElement;
+    element?.addEventListener("mouseenter", handleMouseEnter);
+    element?.addEventListener("mouseleave", handleMouseLeave);
+
+    return () => {
+      element?.removeEventListener("mouseenter", handleMouseEnter);
+      element?.removeEventListener("mouseleave", handleMouseLeave);
+    };
+  }, [handleMouseEnter, handleMouseLeave, parentElement, triggerElement]);
+
+  return (
+    <Transition
+      ref={setTooltipEle}
+      show={showTooltip}
+      static={true}
+      style={styles.popper}
+      as={"div"}
+      enter="transition-opacity duration-150"
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+      leave="transition-opacity duration-150"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+      {...attributes.popper}
+      {...rest}
+    >
+      <div
+        role="tooltip"
+        className={cn(
+          "bg-gray-600",
+          "text-white",
+          "text-xs",
+          "h-min",
+          "py-1",
+          "px-2",
+          "rounded-md",
+          "z-50",
+          "transition-opacity"
+        )}
+      >
+        {content}
+      </div>
+    </Transition>
+  );
+};
 
 export default Tooltip;

--- a/react-app/src/i18n/translations/en.json
+++ b/react-app/src/i18n/translations/en.json
@@ -100,6 +100,7 @@
   "ProposalDetail.votes.remindToVote": "Remind to vote",
   "ProposalDetail.votes.requestState.error": "Failed to fetch proposal votes, please try again later.",
   "ProposalDetail.votes.voter": "Voter",
+  "ProposalDetail.votes.voter.noSecurityContact": "Contact information for this validator is not available",
   "ProposalDetail.votes.voter.validator": "Validator",
   "ProposalDetail.votingDateRange": "{from} to {to}",
   "ProposalDetail.votingDurationRemaining": "{duration} left",

--- a/react-app/src/i18n/translations/zh.json
+++ b/react-app/src/i18n/translations/zh.json
@@ -100,6 +100,7 @@
   "ProposalDetail.votes.remindToVote": "Remind to vote",
   "ProposalDetail.votes.requestState.error": "Failed to fetch proposal votes, please try again later.",
   "ProposalDetail.votes.voter": "Voter",
+  "ProposalDetail.votes.voter.noSecurityContact": "Contact information for this validator is not available",
   "ProposalDetail.votes.voter.validator": "Validator",
   "ProposalDetail.votingDateRange": "{from} 至 {to}",
   "ProposalDetail.votingDurationRemaining": "剩餘{duration}",

--- a/react-app/src/utils/__tests__/regex.ts
+++ b/react-app/src/utils/__tests__/regex.ts
@@ -1,0 +1,33 @@
+import { validateEmail } from "../regex";
+
+describe("validateEmail", () => {
+  it("should fail empty email", () => {
+    const email = "";
+
+    expect(validateEmail(email)).toBe(false);
+  });
+
+  it("should fail invalid email", () => {
+    const email = "invalid";
+
+    expect(validateEmail(email)).toBe(false);
+  });
+
+  it("should pass valid email", () => {
+    const email = "test@exmaple.com";
+
+    expect(validateEmail(email)).toBe(true);
+  });
+
+  it("should pass valid email with plus", () => {
+    const email = "test+2@example.com";
+
+    expect(validateEmail(email)).toBe(true);
+  });
+
+  it("should pass valid email with dots", () => {
+    const email = "test.hello.world@example.com";
+
+    expect(validateEmail(email)).toBe(true);
+  });
+});

--- a/react-app/src/utils/regex.ts
+++ b/react-app/src/utils/regex.ts
@@ -1,0 +1,9 @@
+const EMAIL_REGEX =
+  /^$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+
+export function validateEmail(e: string): boolean {
+  if (!e) {
+    return false;
+  }
+  return EMAIL_REGEX.test(e);
+}


### PR DESCRIPTION
- Refactored tooltip to maintain a self-contained popper state
- Added email validator for security contact checking
- Removed the logic to hide "Remind to vote" button when no email is provided and instead disable the button

## Screenshot
| Desktop | Mobile |
|---------|--------|
|![Screenshot 2022-07-23 at 2 52 22 PM](https://user-images.githubusercontent.com/18374475/180594256-8e7004ae-1fde-4b66-bed3-a7d0ee914525.png)|![Screenshot 2022-07-23 at 2 55 10 PM](https://user-images.githubusercontent.com/18374475/180594259-bfffc0be-65a4-498e-a8a5-f5779ab0bdc1.png)|

refs oursky/likedao#74 