### PR TITLE
Implement validator listing api

### DIFF
--- a/graphql-schema/validator.graphql
+++ b/graphql-schema/validator.graphql
@@ -17,6 +17,7 @@ type Validator implements Node {
 
   votingPower: Float!
   expectedReturns: Float!
+  uptime: Float!
 }
 
 type ValidatorEdge {

--- a/graphql-schema/validator.graphql
+++ b/graphql-schema/validator.graphql
@@ -1,3 +1,8 @@
+enum ValidatorStatusFilter {
+  Active
+  Inactive
+}
+
 type Validator implements Node {
   id: ID!
   consensusAddress: String!
@@ -9,4 +14,34 @@ type Validator implements Node {
   website: String
   securityContact: String
   details: String
+}
+
+type ValidatorEdge {
+  cursor: String!
+  node: Validator!
+}
+
+type ValidatorConnection {
+  pageInfo: PageInfo!
+  edges: [ValidatorEdge!]!
+  totalCount: Int!
+}
+
+input ValidatorSort {
+  name: Sort
+  votingPower: Sort
+  expectedReturns: Sort
+  uptime: Sort
+}
+
+input QueryValidatorsInput {
+  first: Int!
+  after: Int!
+  status: ValidatorStatusFilter
+  searchTerm: String
+  order: ValidatorSort
+}
+
+extend type Query {
+  validators(input: QueryValidatorsInput!): ValidatorConnection!
 }

--- a/graphql-schema/validator.graphql
+++ b/graphql-schema/validator.graphql
@@ -18,6 +18,8 @@ type Validator implements Node {
   votingPower: Float!
   expectedReturns: Float!
   uptime: Float!
+  participatedProposalCount: Int!
+  relativeTotalProposalCount: Int!
 }
 
 type ValidatorEdge {

--- a/graphql-schema/validator.graphql
+++ b/graphql-schema/validator.graphql
@@ -14,6 +14,8 @@ type Validator implements Node {
   website: String
   securityContact: String
   details: String
+
+  votingPower: Float!
 }
 
 type ValidatorEdge {

--- a/graphql-schema/validator.graphql
+++ b/graphql-schema/validator.graphql
@@ -16,6 +16,7 @@ type Validator implements Node {
   details: String
 
   votingPower: Float!
+  expectedReturns: Float!
 }
 
 type ValidatorEdge {

--- a/graphql-schema/validator.graphql
+++ b/graphql-schema/validator.graphql
@@ -3,6 +3,12 @@ enum ValidatorStatusFilter {
   Inactive
 }
 
+enum ValidatorBondingStatus {
+  Bonded
+  Unbonded
+  Unbonding
+}
+
 type Validator implements Node {
   id: ID!
   consensusAddress: String!
@@ -14,6 +20,8 @@ type Validator implements Node {
   website: String
   securityContact: String
   details: String
+  jailed: Boolean
+  status: ValidatorBondingStatus
 
   votingPower: Float!
   expectedReturns: Float!

--- a/graphql-server/go.mod
+++ b/graphql-server/go.mod
@@ -22,11 +22,13 @@ require (
 )
 
 require (
+	github.com/99designs/keyring v1.1.6 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/armon/go-metrics v0.3.8 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
@@ -34,12 +36,17 @@ require (
 	github.com/confio/ics23/go v0.6.6 // indirect
 	github.com/cosmos/cosmos-sdk v0.42.9
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
+	github.com/cosmos/iavl v0.16.0 // indirect
+	github.com/cosmos/ledger-cosmos-go v0.11.1 // indirect
+	github.com/cosmos/ledger-go v0.9.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/danieljoos/wincred v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.2 // indirect
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b // indirect
 	github.com/enigmampc/btcutil v1.0.3-0.20200723161021-e2fb6adb2a25 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
@@ -50,11 +57,16 @@ require (
 	github.com/go-playground/locales v0.13.0 // indirect
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
+	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/protobuf v1.3.3 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3-0.20201103224600-674baa8c7fc3 // indirect
 	github.com/google/btree v1.0.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
@@ -64,6 +76,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/lib/pq v1.9.0 // indirect
@@ -74,16 +87,21 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/oklog/ulid/v2 v2.0.2
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.30.0 // indirect
 	github.com/prometheus/procfs v0.7.1 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
+	github.com/regen-network/cosmos-proto v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect
@@ -93,9 +111,12 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.1 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca // indirect
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
+	github.com/tendermint/btcd v0.1.1 // indirect
+	github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15 // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect
 	github.com/tendermint/tendermint v0.34.11
 	github.com/tendermint/tm-db v0.6.4 // indirect
@@ -104,11 +125,13 @@ require (
 	github.com/urfave/cli/v2 v2.4.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/zondax/hid v0.9.0 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/graphql-server/go.sum
+++ b/graphql-server/go.sum
@@ -51,6 +51,7 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/Workiva/go-datastructures v1.0.52 h1:PLSK6pwn8mYdaoaCZEMsXBpBotr4HHn9abU0yMQt0NI=
 github.com/Workiva/go-datastructures v1.0.52/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
@@ -323,6 +324,7 @@ github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa h1:Q75Upo5UN4JbPFU
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
+github.com/google/orderedcode v0.0.1 h1:UzfcAexk9Vhv8+9pNOgRu41f16lHq725vPwnSeiG/Us=
 github.com/google/orderedcode v0.0.1/go.mod h1:iVyU4/qPKHY5h/wSd6rZZCDcLJNxiWO6dvsYES2Sb20=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -485,6 +487,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 h1:hLDRPB66XQT/8+wG9WsDpiCvZf1yKO7sz7scAjSlBa0=
 github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643/go.mod h1:43+3pMjjKimDBf5Kr4ZFNGbLql1zKkbImw+fZbw3geM=
+github.com/minio/highwayhash v1.0.1 h1:dZ6IIu8Z14VlC0VpfKofAhCy74wu/Qb5gcn52yWoz/0=
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -547,6 +550,7 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
 github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
@@ -635,8 +639,10 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.21.0 h1:Q3vdXlfLNT+OftyBHsU0Y445MD+8m8axjKgf2si0QcM=
 github.com/rs/zerolog v1.21.0/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -695,6 +701,7 @@ github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/graphql-server/gqlgen.yml
+++ b/graphql-server/gqlgen.yml
@@ -130,3 +130,7 @@ models:
     fields:
       id:
         fieldName: NodeID
+  ValidatorConnection:
+    model: github.com/oursky/likedao/pkg/models.ValidatorConnection
+  ValidatorEdge:
+    model: github.com/oursky/likedao/pkg/models.ValidatorEdge

--- a/graphql-server/pkg/context/context.go
+++ b/graphql-server/pkg/context/context.go
@@ -67,7 +67,7 @@ func NewRequestContext(
 		Supply:        queries.NewSupplyQuery(ctx, chainDB),
 		Proposal:      queries.NewProposalQuery(ctx, config, chainDB),
 		Reaction:      queries.NewReactionQuery(ctx, serverDB),
-		Validator:     queries.NewValidatorQuery(ctx, chainDB),
+		Validator:     queries.NewValidatorQuery(ctx, config, chainDB),
 	}
 	mutators := MutatorContext{
 		Test:     mutators.NewTestMutator(ctx, serverDB),

--- a/graphql-server/pkg/dataloaders/validator.go
+++ b/graphql-server/pkg/dataloaders/validator.go
@@ -9,14 +9,20 @@ import (
 type ValidatorDataloader interface {
 	LoadValidatorWithInfoByConsensusAddress(address string) (*models.Validator, error)
 	LoadValidatorWithInfoBySelfDelegationAddress(address string) (*models.Validator, error)
+	LoadRelativeTotalProposalCountByConsensusAddress(address string) (*int, error)
 }
 type ValidatorLoader interface {
 	Load(address string) (*models.Validator, error)
 }
 
+type ProposalCountLoader interface {
+	Load(address string) (*int, error)
+}
+
 type IValidatorDataloader struct {
-	validatorConsensusAddressLoader      ValidatorLoader
-	validatorSelfDelegationAddressLoader ValidatorLoader
+	validatorConsensusAddressLoader                  ValidatorLoader
+	validatorSelfDelegationAddressLoader             ValidatorLoader
+	relativeTotalProposalCountConsensusAddressLoader ProposalCountLoader
 }
 
 func NewValidatorDataloader(validatorQuery queries.IValidatorQuery) ValidatorDataloader {
@@ -52,9 +58,26 @@ func NewValidatorDataloader(validatorQuery queries.IValidatorQuery) ValidatorDat
 		},
 	})
 
+	relativeTotalProposalCountConsensusAddressLoader := godataloader.NewDataLoader(godataloader.DataLoaderConfig[string, *int]{
+		MaxBatch: DefaultMaxBatch,
+		Wait:     DefaultWait,
+		Fetch: func(addresses []string) ([]*int, []error) {
+			counts, err := validatorQuery.QueryRelativeTotalProposalCounts(addresses)
+			if err != nil {
+				errors := make([]error, 0, len(addresses))
+				for range addresses {
+					errors = append(errors, err)
+				}
+				return nil, errors
+			}
+			return counts, nil
+		},
+	})
+
 	return &IValidatorDataloader{
-		validatorConsensusAddressLoader:      validatorConsensusAddressLoader,
-		validatorSelfDelegationAddressLoader: validatorSelfDelegationAddressLoader,
+		validatorConsensusAddressLoader:                  validatorConsensusAddressLoader,
+		validatorSelfDelegationAddressLoader:             validatorSelfDelegationAddressLoader,
+		relativeTotalProposalCountConsensusAddressLoader: relativeTotalProposalCountConsensusAddressLoader,
 	}
 }
 
@@ -64,4 +87,8 @@ func (d *IValidatorDataloader) LoadValidatorWithInfoByConsensusAddress(address s
 
 func (d *IValidatorDataloader) LoadValidatorWithInfoBySelfDelegationAddress(address string) (*models.Validator, error) {
 	return d.validatorSelfDelegationAddressLoader.Load(address)
+}
+
+func (d *IValidatorDataloader) LoadRelativeTotalProposalCountByConsensusAddress(address string) (*int, error) {
+	return d.relativeTotalProposalCountConsensusAddressLoader.Load(address)
 }

--- a/graphql-server/pkg/dataloaders/validator.go
+++ b/graphql-server/pkg/dataloaders/validator.go
@@ -30,7 +30,7 @@ func NewValidatorDataloader(validatorQuery queries.IValidatorQuery) ValidatorDat
 		MaxBatch: DefaultMaxBatch,
 		Wait:     DefaultWait,
 		Fetch: func(addresses []string) ([]*models.Validator, []error) {
-			validators, err := validatorQuery.QueryValidatorsByConsensusAddresses(addresses)
+			validators, err := validatorQuery.WithProposalVotes().WithProposalDeposits().QueryValidatorsByConsensusAddresses(addresses)
 			if err != nil {
 				errors := make([]error, 0, len(addresses))
 				for range addresses {
@@ -46,7 +46,7 @@ func NewValidatorDataloader(validatorQuery queries.IValidatorQuery) ValidatorDat
 		MaxBatch: DefaultMaxBatch,
 		Wait:     DefaultWait,
 		Fetch: func(addresses []string) ([]*models.Validator, []error) {
-			validators, err := validatorQuery.QueryValidatorsBySelfDelegationAddresses(addresses)
+			validators, err := validatorQuery.WithProposalVotes().WithProposalDeposits().QueryValidatorsBySelfDelegationAddresses(addresses)
 			if err != nil {
 				errors := make([]error, 0, len(addresses))
 				for range addresses {

--- a/graphql-server/pkg/models/proposal.go
+++ b/graphql-server/pkg/models/proposal.go
@@ -232,12 +232,12 @@ type ProposalVoteOptionCount struct {
 type ProposalTallyResult struct {
 	bun.BaseModel `bun:"table:proposal_tally_result"`
 
-	ProposalID int         `bun:"column:proposal_id,pk"`
-	Yes        *bunbig.Int `bun:"column:yes,notnull"`
-	No         *bunbig.Int `bun:"column:no,notnull"`
-	Abstain    *bunbig.Int `bun:"column:abstain,notnull"`
-	NoWithVeto *bunbig.Int `bun:"column:no_with_veto,notnull"`
-	Height     int64       `bun:"column:height,notnull"`
+	ProposalID int        `bun:"column:proposal_id,pk"`
+	Yes        bunbig.Int `bun:"column:yes,notnull"`
+	No         bunbig.Int `bun:"column:no,notnull"`
+	Abstain    bunbig.Int `bun:"column:abstain,notnull"`
+	NoWithVeto bunbig.Int `bun:"column:no_with_veto,notnull"`
+	Height     int64      `bun:"column:height,notnull"`
 }
 
 type ProposalTurnout struct {

--- a/graphql-server/pkg/models/staking_pool.go
+++ b/graphql-server/pkg/models/staking_pool.go
@@ -8,7 +8,7 @@ import (
 type StakingPool struct {
 	bun.BaseModel `bun:"table:staking_pool"`
 
-	BondedTokens    *bunbig.Int `bun:"column:bonded_tokens,notnull"`
-	NotBondedTokens *bunbig.Int `bun:"column:not_bonded_tokens,notnull"`
-	Height          int64       `bun:"column:height,notnull"`
+	BondedTokens    bunbig.Int `bun:"column:bonded_tokens,notnull"`
+	NotBondedTokens bunbig.Int `bun:"column:not_bonded_tokens,notnull"`
+	Height          int64      `bun:"column:height,notnull"`
 }

--- a/graphql-server/pkg/models/types.go
+++ b/graphql-server/pkg/models/types.go
@@ -13,7 +13,7 @@ import (
 type BigInt string
 type BigFloat string
 
-func NewBigIntFromBunBigInt(b *bunbig.Int) BigInt {
+func NewBigIntFromBunBigInt(b bunbig.Int) BigInt {
 	return BigInt(b.String())
 }
 

--- a/graphql-server/pkg/models/validator.go
+++ b/graphql-server/pkg/models/validator.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/extra/bunbig"
 )
@@ -16,6 +18,7 @@ type Validator struct {
 	Status      *ValidatorStatus      `bun:"rel:has-one,join:consensus_address=validator_address"`
 	VotingPower *ValidatorVotingPower `bun:"rel:has-one,join:consensus_address=validator_address"`
 	Commission  *ValidatorCommission  `bun:"rel:has-one,join:consensus_address=validator_address"`
+	SigningInfo *ValidatorSigningInfo `bun:"rel:has-one,join:consensus_address=validator_address"`
 }
 
 func (p Validator) IsNode()              {}
@@ -87,4 +90,18 @@ type ValidatorCommission struct {
 	Height            int64         `bun:"column:height,notnull"`
 
 	ExpectedReturns float64 `json:"expected_returns"`
+}
+
+type ValidatorSigningInfo struct {
+	bun.BaseModel `bun:"table:validator_signing_info"`
+
+	ConsensusAddress    string    `bun:"column:validator_address,pk"`
+	StartHeight         int64     `bun:"column:start_height,notnull"`
+	IndexOffset         int64     `bun:"column:index_offset,notnull"`
+	JailedUntil         time.Time `bun:"column:jailed_until,notnull"`
+	Tombstoned          bool      `bun:"column:tombstoned,notnull"`
+	MissedBlocksCounter int64     `bun:"column:missed_blocks_counter,notnull"`
+	Height              int64     `bun:"column:height,notnull"`
+
+	Uptime float64 `json:"uptime"`
 }

--- a/graphql-server/pkg/models/validator.go
+++ b/graphql-server/pkg/models/validator.go
@@ -74,9 +74,9 @@ type ValidatorStatus struct {
 type ValidatorVotingPower struct {
 	bun.BaseModel `bun:"table:validator_voting_power"`
 
-	ConsensusAddress string      `bun:"column:validator_address,pk"`
-	VotingPower      *bunbig.Int `bun:"column:voting_power,notnull"`
-	Height           int64       `bun:"column:height,notnull"`
+	ConsensusAddress string     `bun:"column:validator_address,pk"`
+	VotingPower      bunbig.Int `bun:"column:voting_power,notnull"`
+	Height           int64      `bun:"column:height,notnull"`
 
 	RelativeVotingPower float64 `json:"relative_voting_power"`
 }
@@ -84,10 +84,10 @@ type ValidatorVotingPower struct {
 type ValidatorCommission struct {
 	bun.BaseModel `bun:"table:validator_commission"`
 
-	ConsensusAddress  string        `bun:"column:validator_address,pk"`
-	Commission        *bunbig.Float `bun:"column:commission,notnull"`
-	MinSelfDelegation *bunbig.Int   `bun:"column:min_self_delegation,notnull"`
-	Height            int64         `bun:"column:height,notnull"`
+	ConsensusAddress  string       `bun:"column:validator_address,pk"`
+	Commission        bunbig.Float `bun:"column:commission,notnull"`
+	MinSelfDelegation bunbig.Int   `bun:"column:min_self_delegation,notnull"`
+	Height            int64        `bun:"column:height,notnull"`
 
 	ExpectedReturns float64 `json:"expected_returns"`
 }

--- a/graphql-server/pkg/models/validator.go
+++ b/graphql-server/pkg/models/validator.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/extra/bunbig"
 )
 
 type Validator struct {
@@ -13,6 +14,7 @@ type Validator struct {
 	Description *ValidatorDescription `bun:"rel:has-one,join:consensus_address=validator_address"`
 	Info        *ValidatorInfo        `bun:"rel:has-one,join:consensus_address=consensus_address"`
 	Status      *ValidatorStatus      `bun:"rel:has-one,join:consensus_address=validator_address"`
+	VotingPower *ValidatorVotingPower `bun:"rel:has-one,join:consensus_address=validator_address"`
 }
 
 func (p Validator) IsNode()              {}
@@ -63,4 +65,14 @@ type ValidatorStatus struct {
 	Jailed           bool   `bun:"column:jailed,notnull"`
 	Tombstoned       bool   `bun:"column:tombstoned,notnull"`
 	Height           int64  `bun:"column:height,notnull"`
+}
+
+type ValidatorVotingPower struct {
+	bun.BaseModel `bun:"table:validator_voting_power"`
+
+	ConsensusAddress string      `bun:"column:validator_address,pk"`
+	VotingPower      *bunbig.Int `bun:"column:voting_power,notnull"`
+	Height           int64       `bun:"column:height,notnull"`
+
+	RelativeVotingPower float64 `json:"relative_voting_power"`
 }

--- a/graphql-server/pkg/models/validator.go
+++ b/graphql-server/pkg/models/validator.go
@@ -105,3 +105,8 @@ type ValidatorSigningInfo struct {
 
 	Uptime float64 `json:"uptime"`
 }
+
+type DBRelativeTotalProposalCount struct {
+	ConsensusAddress string `json:"consensus_address"`
+	ProposalCount    int    `json:"proposal_count"`
+}

--- a/graphql-server/pkg/models/validator.go
+++ b/graphql-server/pkg/models/validator.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/uptrace/bun"
+import (
+	"github.com/uptrace/bun"
+)
 
 type Validator struct {
 	bun.BaseModel `bun:"table:validator"`
@@ -10,6 +12,7 @@ type Validator struct {
 
 	Description *ValidatorDescription `bun:"rel:has-one,join:consensus_address=validator_address"`
 	Info        *ValidatorInfo        `bun:"rel:has-one,join:consensus_address=consensus_address"`
+	Status      *ValidatorStatus      `bun:"rel:has-one,join:consensus_address=validator_address"`
 }
 
 func (p Validator) IsNode()              {}
@@ -18,6 +21,9 @@ func (p Validator) IsProposalDepositor() {}
 func (p Validator) NodeID() NodeID {
 	return GetNodeID(p)
 }
+
+type ValidatorConnection = Connection[Validator]
+type ValidatorEdge = Edge[Validator]
 
 type ValidatorDescription struct {
 	bun.BaseModel `bun:"table:validator_description"`
@@ -47,4 +53,14 @@ type ValidatorInfo struct {
 	Validator        *Validator         `bun:"rel:belongs-to,join:consensus_address=consensus_address"`
 	ProposalVotes    []*ProposalVote    `bun:"rel:has-many,join:self_delegate_address=voter_address"`
 	ProposalDeposits []*ProposalDeposit `bun:"rel:has-many,join:self_delegate_address=depositor_address"`
+}
+
+type ValidatorStatus struct {
+	bun.BaseModel `bun:"table:validator_status"`
+
+	ConsensusAddress string `bun:"column:validator_address,pk"`
+	Status           int    `bun:"column:status,notnull"`
+	Jailed           bool   `bun:"column:jailed,notnull"`
+	Tombstoned       bool   `bun:"column:tombstoned,notnull"`
+	Height           int64  `bun:"column:height,notnull"`
 }

--- a/graphql-server/pkg/models/validator.go
+++ b/graphql-server/pkg/models/validator.go
@@ -15,6 +15,7 @@ type Validator struct {
 	Info        *ValidatorInfo        `bun:"rel:has-one,join:consensus_address=consensus_address"`
 	Status      *ValidatorStatus      `bun:"rel:has-one,join:consensus_address=validator_address"`
 	VotingPower *ValidatorVotingPower `bun:"rel:has-one,join:consensus_address=validator_address"`
+	Commission  *ValidatorCommission  `bun:"rel:has-one,join:consensus_address=validator_address"`
 }
 
 func (p Validator) IsNode()              {}
@@ -75,4 +76,15 @@ type ValidatorVotingPower struct {
 	Height           int64       `bun:"column:height,notnull"`
 
 	RelativeVotingPower float64 `json:"relative_voting_power"`
+}
+
+type ValidatorCommission struct {
+	bun.BaseModel `bun:"table:validator_commission"`
+
+	ConsensusAddress  string        `bun:"column:validator_address,pk"`
+	Commission        *bunbig.Float `bun:"column:commission,notnull"`
+	MinSelfDelegation *bunbig.Int   `bun:"column:min_self_delegation,notnull"`
+	Height            int64         `bun:"column:height,notnull"`
+
+	ExpectedReturns float64 `json:"expected_returns"`
 }

--- a/graphql-server/pkg/queries/block.go
+++ b/graphql-server/pkg/queries/block.go
@@ -13,6 +13,7 @@ type IBlockQuery interface {
 	QueryLatestBlock() (*models.Block, error)
 	QueryBlockByHash(hash string) (*models.Block, error)
 	QueryBlocksByHashes(hashes []string) ([]*models.Block, error)
+	QueryBlocksByHeights(heights []int64) ([]*models.Block, error)
 }
 
 type BlockQuery struct {
@@ -45,7 +46,7 @@ func (q *BlockQuery) QueryBlockByHash(hash string) (*models.Block, error) {
 }
 
 func (q *BlockQuery) QueryBlocksByHashes(hashes []string) ([]*models.Block, error) {
-	blocks := make([]*models.Block, 0, len(hashes))
+	blocks := make([]models.Block, 0)
 	uppercasedHashes := make([]string, 0, len(hashes))
 	for _, hash := range hashes {
 		uppercasedHashes = append(uppercasedHashes, strings.ToUpper(hash))
@@ -57,11 +58,35 @@ func (q *BlockQuery) QueryBlocksByHashes(hashes []string) ([]*models.Block, erro
 	result := make([]*models.Block, 0, len(blocks))
 	hashToBlock := make(map[string]models.Block, len(blocks))
 	for _, block := range blocks {
-		hashToBlock[block.Hash] = *block
+		hashToBlock[block.Hash] = block
 	}
 
 	for _, hash := range uppercasedHashes {
 		block, exists := hashToBlock[hash]
+		if exists {
+			result = append(result, &block)
+		} else {
+			result = append(result, nil)
+		}
+	}
+
+	return result, nil
+}
+
+func (q *BlockQuery) QueryBlocksByHeights(heights []int64) ([]*models.Block, error) {
+	blocks := make([]models.Block, 0)
+	if err := q.session.NewSelect().Model(&blocks).Where("height IN (?)", bun.In(heights)).Scan(q.ctx); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	result := make([]*models.Block, 0, len(heights))
+	heightToBlock := make(map[int64]models.Block, len(blocks))
+	for _, block := range blocks {
+		heightToBlock[int64(block.Height)] = block
+	}
+
+	for _, height := range heights {
+		block, exists := heightToBlock[height]
 		if exists {
 			result = append(result, &block)
 		} else {

--- a/graphql-server/pkg/queries/proposal.go
+++ b/graphql-server/pkg/queries/proposal.go
@@ -443,13 +443,13 @@ func (q *ProposalQuery) QueryProposalVoteCountByAddress(address string) (*models
 	for _, voteCount := range res {
 		switch voteCount.Option {
 		case models.ProposalVoteOptionYes:
-			distribution.Yes = &voteCount.Count
+			distribution.Yes = voteCount.Count
 		case models.ProposalVoteOptionNo:
-			distribution.No = &voteCount.Count
+			distribution.No = voteCount.Count
 		case models.ProposalVoteOptionAbstain:
-			distribution.Abstain = &voteCount.Count
+			distribution.Abstain = voteCount.Count
 		case models.ProposalVoteOptionNoWithVeto:
-			distribution.NoWithVeto = &voteCount.Count
+			distribution.NoWithVeto = voteCount.Count
 		default:
 			return nil, servererrors.InternalError.NewError(q.ctx, "invalid vote option encountered")
 		}

--- a/graphql-server/pkg/queries/validator.go
+++ b/graphql-server/pkg/queries/validator.go
@@ -78,6 +78,7 @@ func (q *ValidatorQuery) NewQuery(model interface{}, includeAddresses []string) 
 				Column("validator_address", "start_height", "index_offset", "jailed_until", "tombstoned", "missed_blocks_counter", "height").
 				ColumnExpr("(1 - (missed_blocks_counter::decimal / ((?) - start_height::decimal))) as signing_info__uptime", latestBlockQuery)
 		}).
+		Relation("Status").
 		// To handle gql resolving when info is provided but validator isn't
 		Relation("Info.Validator")
 

--- a/graphql-server/pkg/resolvers/block.go
+++ b/graphql-server/pkg/resolvers/block.go
@@ -22,7 +22,7 @@ func (r *queryResolver) LatestBlock(ctx context.Context) (*models.Block, error) 
 }
 
 func (r *queryResolver) BlockByID(ctx context.Context, id models.NodeID) (*models.Block, error) {
-	res, err := pkgContext.GetDataLoadersFromCtx(ctx).Block.Load(id.ID)
+	res, err := pkgContext.GetDataLoadersFromCtx(ctx).Block.LoadBlockByHash(id.ID)
 	if err != nil {
 		return nil, servererrors.QueryError.NewError(ctx, fmt.Sprintf("failed to query block: %v", err))
 	}
@@ -31,7 +31,7 @@ func (r *queryResolver) BlockByID(ctx context.Context, id models.NodeID) (*model
 
 func (r *queryResolver) BlocksByIDs(ctx context.Context, ids []models.NodeID) ([]*models.Block, error) {
 	blockHashes := models.ExtractObjectIDs(ids)
-	res, errs := pkgContext.GetDataLoadersFromCtx(ctx).Block.LoadAll(blockHashes)
+	res, errs := pkgContext.GetDataLoadersFromCtx(ctx).Block.LoadBlockByHashes(blockHashes)
 
 	for _, err := range errs {
 		if err != nil {

--- a/graphql-server/pkg/resolvers/proposal.go
+++ b/graphql-server/pkg/resolvers/proposal.go
@@ -344,30 +344,18 @@ func (r *proposalDepositResolver) Depositor(ctx context.Context, obj *models.Pro
 }
 
 func (r *proposalTallyResultResolver) Yes(ctx context.Context, obj *models.ProposalTallyResult) (models.BigInt, error) {
-	if obj.Yes == nil {
-		return models.NewBigInt(0), nil
-	}
 	return models.NewBigIntFromBunBigInt(obj.Yes), nil
 }
 
 func (r *proposalTallyResultResolver) No(ctx context.Context, obj *models.ProposalTallyResult) (models.BigInt, error) {
-	if obj.No == nil {
-		return models.NewBigInt(0), nil
-	}
 	return models.NewBigIntFromBunBigInt(obj.No), nil
 }
 
 func (r *proposalTallyResultResolver) NoWithVeto(ctx context.Context, obj *models.ProposalTallyResult) (models.BigInt, error) {
-	if obj.NoWithVeto == nil {
-		return models.NewBigInt(0), nil
-	}
 	return models.NewBigIntFromBunBigInt(obj.NoWithVeto), nil
 }
 
 func (r *proposalTallyResultResolver) Abstain(ctx context.Context, obj *models.ProposalTallyResult) (models.BigInt, error) {
-	if obj.Abstain == nil {
-		return models.NewBigInt(0), nil
-	}
 	return models.NewBigIntFromBunBigInt(obj.Abstain), nil
 }
 
@@ -376,22 +364,22 @@ func (r *proposalTallyResultResolver) OutstandingOption(ctx context.Context, obj
 	var votes = int64(0)
 
 	// FIXME: Improve this handling
-	if obj.Yes != nil && obj.Yes.ToInt64() > votes {
+	if obj.Yes.ToInt64() > votes {
 		*option = models.ProposalVoteOptionYes
 		votes = obj.Yes.ToInt64()
 	}
 
-	if obj.No != nil && obj.No.ToInt64() > votes {
+	if obj.No.ToInt64() > votes {
 		*option = models.ProposalVoteOptionNo
 		votes = obj.No.ToInt64()
 	}
 
-	if obj.NoWithVeto != nil && obj.NoWithVeto.ToInt64() > votes {
+	if obj.NoWithVeto.ToInt64() > votes {
 		*option = models.ProposalVoteOptionNoWithVeto
 		votes = obj.NoWithVeto.ToInt64()
 	}
 
-	if obj.Abstain != nil && obj.Abstain.ToInt64() > votes {
+	if obj.Abstain.ToInt64() > votes {
 		*option = models.ProposalVoteOptionAbstain
 	}
 

--- a/graphql-server/pkg/resolvers/validator.go
+++ b/graphql-server/pkg/resolvers/validator.go
@@ -17,6 +17,10 @@ import (
 func (r *queryResolver) Validators(ctx context.Context, input models.QueryValidatorsInput) (*models.Connection[models.Validator], error) {
 	validatorQuery := pkgContext.GetQueriesFromCtx(ctx).Validator
 
+	if input.Status != nil {
+		validatorQuery = validatorQuery.ScopeValidatorStatus(*input.Status)
+	}
+
 	res, err := validatorQuery.QueryPaginatedValidators(input.First, input.After, []string{})
 	if err != nil {
 		return nil, servererrors.QueryError.NewError(ctx, fmt.Sprintf("failed to query validators: %v", err))

--- a/graphql-server/pkg/resolvers/validator.go
+++ b/graphql-server/pkg/resolvers/validator.go
@@ -197,6 +197,19 @@ func (r *validatorResolver) ExpectedReturns(ctx context.Context, obj *models.Val
 	return validator.Commission.ExpectedReturns, nil
 }
 
+func (r *validatorResolver) Uptime(ctx context.Context, obj *models.Validator) (float64, error) {
+	validator, err := pkgContext.GetDataLoadersFromCtx(ctx).Validator.LoadValidatorWithInfoByConsensusAddress(obj.ConsensusAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	if validator.SigningInfo == nil {
+		return 0, nil
+	}
+
+	return validator.SigningInfo.Uptime, nil
+}
+
 // Validator returns graphql1.ValidatorResolver implementation.
 func (r *Resolver) Validator() graphql1.ValidatorResolver { return &validatorResolver{r} }
 

--- a/graphql-server/pkg/resolvers/validator.go
+++ b/graphql-server/pkg/resolvers/validator.go
@@ -184,6 +184,19 @@ func (r *validatorResolver) VotingPower(ctx context.Context, obj *models.Validat
 	return validator.VotingPower.RelativeVotingPower, nil
 }
 
+func (r *validatorResolver) ExpectedReturns(ctx context.Context, obj *models.Validator) (float64, error) {
+	validator, err := pkgContext.GetDataLoadersFromCtx(ctx).Validator.LoadValidatorWithInfoByConsensusAddress(obj.ConsensusAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	if validator.Commission == nil {
+		return 0, nil
+	}
+
+	return validator.Commission.ExpectedReturns, nil
+}
+
 // Validator returns graphql1.ValidatorResolver implementation.
 func (r *Resolver) Validator() graphql1.ValidatorResolver { return &validatorResolver{r} }
 

--- a/graphql-server/pkg/resolvers/validator.go
+++ b/graphql-server/pkg/resolvers/validator.go
@@ -210,6 +210,32 @@ func (r *validatorResolver) Uptime(ctx context.Context, obj *models.Validator) (
 	return validator.SigningInfo.Uptime, nil
 }
 
+func (r *validatorResolver) ParticipatedProposalCount(ctx context.Context, obj *models.Validator) (int, error) {
+	validator, err := pkgContext.GetDataLoadersFromCtx(ctx).Validator.LoadValidatorWithInfoByConsensusAddress(obj.ConsensusAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	if validator.Info == nil {
+		return 0, nil
+	}
+
+	return len(validator.Info.ProposalVotes), nil
+}
+
+func (r *validatorResolver) RelativeTotalProposalCount(ctx context.Context, obj *models.Validator) (int, error) {
+	count, err := pkgContext.GetDataLoadersFromCtx(ctx).Validator.LoadRelativeTotalProposalCountByConsensusAddress(obj.ConsensusAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	if count == nil {
+		return 0, err
+	}
+
+	return *count, nil
+}
+
 // Validator returns graphql1.ValidatorResolver implementation.
 func (r *Resolver) Validator() graphql1.ValidatorResolver { return &validatorResolver{r} }
 

--- a/graphql-server/pkg/resolvers/validator.go
+++ b/graphql-server/pkg/resolvers/validator.go
@@ -21,6 +21,10 @@ func (r *queryResolver) Validators(ctx context.Context, input models.QueryValida
 		validatorQuery = validatorQuery.ScopeValidatorStatus(*input.Status)
 	}
 
+	if input.Order != nil {
+		validatorQuery = validatorQuery.ValidatorOrderBy(*input.Order)
+	}
+
 	res, err := validatorQuery.QueryPaginatedValidators(input.First, input.After, []string{})
 	if err != nil {
 		return nil, servererrors.QueryError.NewError(ctx, fmt.Sprintf("failed to query validators: %v", err))

--- a/graphql-server/pkg/resolvers/validator.go
+++ b/graphql-server/pkg/resolvers/validator.go
@@ -171,6 +171,19 @@ func (r *validatorResolver) Details(ctx context.Context, obj *models.Validator) 
 	return &validator.Description.Details, nil
 }
 
+func (r *validatorResolver) VotingPower(ctx context.Context, obj *models.Validator) (float64, error) {
+	validator, err := pkgContext.GetDataLoadersFromCtx(ctx).Validator.LoadValidatorWithInfoByConsensusAddress(obj.ConsensusAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	if validator.VotingPower == nil {
+		return 0, nil
+	}
+
+	return validator.VotingPower.RelativeVotingPower, nil
+}
+
 // Validator returns graphql1.ValidatorResolver implementation.
 func (r *Resolver) Validator() graphql1.ValidatorResolver { return &validatorResolver{r} }
 


### PR DESCRIPTION
Feels a bit forced to put everything db level for sorting 

- Added uptime, expected return, voting power and participation to validator object
- Implemented paginated validator query with filtering by status, sort by name, voting power, expected return, uptime

I also have a frontend pagination branch with everything fetched from rpc ready so if this one doesn't work well let's use that one, if the fetch time is acceptable that is.

### Note that this api requires a lot of bdjuno table to be intact to work, might need a dump for it to work
- Supply, Inflation, Staking Pool, All validator tables

refs oursky/likedao#305  