### PR TITLE
Add ingress class to ingress template

### DIFF
--- a/deploy/likedao/templates/ingress.yaml
+++ b/deploy/likedao/templates/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
     kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
     - host: {{ .Values.host }}


### PR DESCRIPTION
Got an error for missing class field when deploying to production k3s

Checked other projects and apparently some of them have it and some of them don't 
Consulted Louis and he said just add it 😂 