### PR TITLE
Update bdjuno submodule target branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "bdjuno/bdjuno"]
 	path = bdjuno/bdjuno
-	url = git@github.com:forbole/bdjuno.git
-	branch = aaron/likecoin_dual_prefix
+	url = https://github.com/forbole/bdjuno.git
+	branch = chains/likecoin/mainnet

--- a/bdjuno/Makefile
+++ b/bdjuno/Makefile
@@ -2,7 +2,7 @@ GENESIS_URL?=https://raw.githubusercontent.com/likecoin/mainnet/master/genesis.j
 
 .PHONY: init
 init: 
-	git submodule update --init --recursive
+	git submodule update --init --recursive --remote
 
 .PHONY: setup
 setup: init

--- a/bdjuno/config.example.yaml
+++ b/bdjuno/config.example.yaml
@@ -1,7 +1,7 @@
 chain:
   bech32_prefix:
-    - cosmos
     - like
+    - cosmos
   modules:
     - modules
     - messages
@@ -30,6 +30,7 @@ parsing:
   parse_genesis: true
   start_height: 1
   average_block_time: 5s
+  genesis_file_path: /bdjuno/.bdjuno/genesis.json
 database:
   name: bdjuno
   host: bdjuno-db

--- a/deploy/likedao/templates/bdjuno.config.yaml
+++ b/deploy/likedao/templates/bdjuno.config.yaml
@@ -40,6 +40,7 @@ data:
         parse_genesis: true
         start_height: {{ .Values.bdjuno.config.parsing.startHeight }}
         average_block_time: {{ .Values.bdjuno.config.parsing.averageBlockTime }}
+        genesis_file_path: /bdjuno/.bdjuno/genesis.json
     database:
         name: {{ .Values.bdjuno.config.database.name }}
         host: {{ .Values.bdjuno.config.database.host }}

--- a/deploy/likedao/values.sample.yaml
+++ b/deploy/likedao/values.sample.yaml
@@ -72,8 +72,8 @@ bdjuno:
     loggingLevel: debug
     chain:
       bech32Prefix:
-        - cosmos
         - like
+        - cosmos
       additionalModules:
     rpc:
       clientName: juno


### PR DESCRIPTION
- Fixed bdjuno parsing error by rearranging the supported prefix order
- Specify genesis file path in config 


## Deprecated

https://github.com/hochiw/bdjuno/commit/368079c4e91fe56537ec3e22ac5e782f4d9abf91

The genesis parsing process for the staking module works as follows

Parse transaction -> Add validator to db -> Add validator description to db -> etc etc

Currently it adds a genesis validator to the db in `cosmos` prefix, then convert the address and then add the validator description in `like` prefix, hence the following error is yielded

```
likedao-bdjuno-1  | 4:38AM DBG parsing genesis module=auth
likedao-bdjuno-1  | 4:38AM DBG parsing genesis module=consensus
likedao-bdjuno-1  | 4:38AM DBG parsing genesis module=gov
likedao-bdjuno-1  | 4:38AM DBG parsing genesis module=mint
likedao-bdjuno-1  | 4:38AM DBG parsing genesis module=slashing
likedao-bdjuno-1  | 4:38AM DBG parsing genesis module=staking
likedao-bdjuno-1  | 4:38AM ERR error while handling genesis err="error while storing genesis transactions: error while storing validators from MsgCreateValidator: cannot find the consensus address of validator having operator address likevaloper155s3xuruk2vnynda9gq6x9e7uzvut746z6dx97" module=staking
likedao-bdjuno-1  | 4:38AM DBG parsing genesis module=distribution
```

My fix puts the address translation process before the `add validator` step so that everything is added correctly.

See if this makes any sense 🙏

refs oursky/likedao#34