### PR TITLE
Add error log to transaction error toast

### DIFF
--- a/react-app/src/components/CreateProposalScreen/CreateProposalScreen.tsx
+++ b/react-app/src/components/CreateProposalScreen/CreateProposalScreen.tsx
@@ -16,6 +16,7 @@ import { ProposalType } from "../../models/cosmos/gov";
 import { useLocale } from "../../providers/AppLocaleProvider";
 import AppRoutes from "../../navigation/AppRoutes";
 import GovernanceInfoPanel from "../GovernanceInfoPanel/GovernanceInfoPanel";
+import TransactionError from "../common/TransactionError/TransactionError";
 
 const CreateProposalScreen: React.FC = () => {
   const wallet = useWallet();
@@ -88,8 +89,8 @@ const CreateProposalScreen: React.FC = () => {
 
         return;
       } catch (e: unknown) {
-        console.error("Error signing send token tx", e);
-        toast.error(translate("transaction.failure"));
+        toast.error(<TransactionError error={e} />);
+        console.error("Error signing create proposal tx", e);
         setIsSubmissionModalActive(false);
       }
     },

--- a/react-app/src/components/ProposalDetailScreen/ProposalDetailScreen.tsx
+++ b/react-app/src/components/ProposalDetailScreen/ProposalDetailScreen.tsx
@@ -22,6 +22,7 @@ import { useCosmosAPI } from "../../api/cosmosAPI";
 import { useGovAPI } from "../../api/govAPI";
 import { DepositProposalFormValues } from "../forms/DepositProposalForm/DepositProposalFormModel";
 import DepositProposalModal from "../TransactionModals/DepositProposalModal";
+import TransactionError from "../common/TransactionError/TransactionError";
 import ProposalHeader from "./ProposalHeader";
 import ProposalDescription from "./ProposalDescription";
 import { useProposalQuery } from "./ProposalDetailScreenAPI";
@@ -146,7 +147,7 @@ const ProposalDetailScreen: React.FC = () => {
         await wallet.refreshAccount();
       } catch (err: unknown) {
         console.error("Error signing send token tx", err);
-        toast.error(translate("transaction.failure"));
+        toast.error(<TransactionError error={err} />);
         closeModals();
       }
     },
@@ -174,7 +175,7 @@ const ProposalDetailScreen: React.FC = () => {
         await wallet.refreshAccount();
       } catch (err: unknown) {
         console.error("Error signing send token tx", err);
-        toast.error(translate("transaction.failure"));
+        toast.error(<TransactionError error={err} />);
         closeModals();
       }
     },

--- a/react-app/src/components/ValidatorDetailScreen/ValidatorDetailScreen.tsx
+++ b/react-app/src/components/ValidatorDetailScreen/ValidatorDetailScreen.tsx
@@ -20,6 +20,7 @@ import UnstakeTokenModal from "../TransactionModals/UnstakeTokenModal";
 import { useStakingAPI } from "../../api/stakingAPI";
 import { useLocale } from "../../providers/AppLocaleProvider";
 import { useCosmosAPI } from "../../api/cosmosAPI";
+import TransactionError from "../common/TransactionError/TransactionError";
 import ValidatorDetailDescriptionPanel from "./ValidatorDetailDescriptionPanel";
 import ValidatorDetailYourStakes from "./ValidatorDetailYourStakesPanel";
 import { useValidatorQuery } from "./ValidatorDetailScreenAPI";
@@ -113,7 +114,7 @@ const ValidatorDetailScreen: React.FC = () => {
         await wallet.refreshAccount();
       } catch (err: unknown) {
         console.error("Error signing delegate token tx", err);
-        toast.error(translate("transaction.failure"));
+        toast.error(<TransactionError error={err} />);
         closeModals();
       }
     },
@@ -141,7 +142,7 @@ const ValidatorDetailScreen: React.FC = () => {
         await wallet.refreshAccount();
       } catch (err: unknown) {
         console.error("Error signing delegate token tx", err);
-        toast.error(translate("transaction.failure"));
+        toast.error(<TransactionError error={err} />);
         closeModals();
       }
     },

--- a/react-app/src/components/common/TransactionError/TransactionError.tsx
+++ b/react-app/src/components/common/TransactionError/TransactionError.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import LocalizedText from "../Localized/LocalizedText";
+
+interface TransactionErrorProps {
+  error: unknown;
+}
+
+const TransactionError: React.FC<TransactionErrorProps> = (props) => {
+  const { error } = props;
+  return (
+    <span>
+      <b>
+        <LocalizedText messageID="transaction.failure" />
+      </b>
+      <br />
+      <LocalizedText
+        messageID="transaction.failure.systemLog"
+        messageArgs={{
+          error: error instanceof Error ? error.message : "Unknown Error",
+        }}
+      />
+    </span>
+  );
+};
+
+export default TransactionError;

--- a/react-app/src/i18n/translations/en.json
+++ b/react-app/src/i18n/translations/en.json
@@ -244,5 +244,6 @@
   "reactions.whatever": "Whatever",
   "transaction.broadcasting": "Broadcasting transaction...",
   "transaction.failure": "Transaction failed",
+  "transaction.failure.systemLog": "System message: \"{error}\"",
   "transaction.success": "Transaction broadcasted"
 }

--- a/react-app/src/i18n/translations/zh.json
+++ b/react-app/src/i18n/translations/zh.json
@@ -244,5 +244,6 @@
   "reactions.whatever": "Whatever",
   "transaction.broadcasting": "Broadcasting transaction...",
   "transaction.failure": "Transaction failed",
+  "transaction.failure.systemLog": "System message: \"{error}\"",
   "transaction.success": "Transaction broadcasted"
 }

--- a/react-app/src/providers/TransactionProvider.tsx
+++ b/react-app/src/providers/TransactionProvider.tsx
@@ -9,6 +9,7 @@ import UserAddressModal from "../components/UserAddressModal/UserAddressModal";
 import { CollectRewardsFormValues } from "../components/forms/CollectRewardsForm/CollectRewardsFormModel";
 import { useDistributionAPI } from "../api/distributionAPI";
 import CollectRewardsModal from "../components/TransactionModals/CollectRewardsModal";
+import TransactionError from "../components/common/TransactionError/TransactionError";
 import { useLocale } from "./AppLocaleProvider";
 import { ConnectionStatus, useWallet } from "./WalletProvider";
 
@@ -91,7 +92,7 @@ const TransactionProvider: React.FC<TransactionProviderProps> = (props) => {
         await wallet.refreshAccount();
       } catch (err: unknown) {
         console.error("Error signing send token tx", err);
-        toast.error(translate("transaction.failure"));
+        toast.error(<TransactionError error={err} />);
         closeModals();
       }
     },
@@ -117,7 +118,7 @@ const TransactionProvider: React.FC<TransactionProviderProps> = (props) => {
         await wallet.refreshAccount();
       } catch (err: unknown) {
         console.error("Error signing send token tx", err);
-        toast.error(translate("transaction.failure"));
+        toast.error(<TransactionError error={err} />);
         closeModals();
       }
     },


### PR DESCRIPTION
- Created transaction error component
- Integrated to all transaction promises

<img width="345" alt="Screenshot 2022-07-29 at 1 07 21 PM" src="https://user-images.githubusercontent.com/18374475/181687077-44fd89cb-7c08-4e48-a207-5188b20ad2e4.png">

refs oursky/likedao#330 